### PR TITLE
Add CancelNil virus

### DIFF
--- a/release.go
+++ b/release.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gtramontina/ooze/viruses/arithmeticassignment"
 	"github.com/gtramontina/ooze/viruses/arithmeticassignmentinvert"
 	"github.com/gtramontina/ooze/viruses/bitwise"
+	"github.com/gtramontina/ooze/viruses/cancelnil"
 	"github.com/gtramontina/ooze/viruses/comparison"
 	"github.com/gtramontina/ooze/viruses/comparisoninvert"
 	"github.com/gtramontina/ooze/viruses/comparisonreplace"
@@ -58,6 +59,7 @@ var defaultOptions = Options{ //nolint:gochecknoglobals
 		arithmeticassignment.New(),
 		arithmeticassignmentinvert.New(),
 		bitwise.New(),
+		cancelnil.New(),
 		comparison.New(),
 		comparisoninvert.New(),
 		comparisonreplace.New(),

--- a/viruses/cancelnil/cancelnil.go
+++ b/viruses/cancelnil/cancelnil.go
@@ -1,0 +1,48 @@
+package cancelnil
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/gtramontina/ooze/viruses"
+)
+
+type CancelNil struct{}
+
+var _ viruses.Virus = (*CancelNil)(nil)
+
+// New returns a new CancelNil virus. It changes calls to context.CancelCauseFunc to pass nil.
+func New() *CancelNil {
+	return &CancelNil{}
+}
+
+func (v *CancelNil) Incubate(node ast.Node, typeInfo *types.Info) []*viruses.Infection {
+	call, ok := node.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+
+	funType := typeInfo.TypeOf(call.Fun)
+	if funType == nil {
+		return nil
+	}
+
+	if funType.String() != "context.CancelCauseFunc" {
+		return nil
+	}
+
+	origArg := call.Args[0]
+
+	if ident, ok := origArg.(*ast.Ident); ok && ident.Name == "nil" {
+		return nil
+	}
+
+	return []*viruses.Infection{
+		viruses.NewInfection(
+			"Call cancel(nil)",
+			func() { call.Args[0] = &ast.Ident{Name: "nil", NamePos: token.NoPos, Obj: nil} },
+			func() { call.Args[0] = origArg },
+		),
+	}
+}

--- a/viruses/cancelnil/cancelnil_test.go
+++ b/viruses/cancelnil/cancelnil_test.go
@@ -1,0 +1,30 @@
+package cancelnil_test
+
+import (
+	"testing"
+
+	"github.com/gtramontina/ooze/oozetesting"
+	"github.com/gtramontina/ooze/viruses/cancelnil"
+)
+
+func TestCancelNil(t *testing.T) {
+	oozetesting.Run(t, oozetesting.NewScenarios(
+		"Call cancel(nil)",
+		cancelnil.New(),
+		oozetesting.Mutations{
+			// "no mutations": {"source.0.go", []string{}},
+			"one mutation": {"source.1.go", []string{
+				"source.1.mut.1.go",
+			}},
+			"two mutations": {"source.2.go", []string{
+				"source.2.mut.1.go",
+				"source.2.mut.2.go",
+			}},
+			"many mutations": {"source.3.go", []string{
+				"source.3.mut.1.go",
+				"source.3.mut.2.go",
+				"source.3.mut.3.go",
+			}},
+		},
+	))
+}

--- a/viruses/cancelnil/cancelnil_test.go
+++ b/viruses/cancelnil/cancelnil_test.go
@@ -12,7 +12,7 @@ func TestCancelNil(t *testing.T) {
 		"Call cancel(nil)",
 		cancelnil.New(),
 		oozetesting.Mutations{
-			// "no mutations": {"source.0.go", []string{}},
+			"no mutations": {"source.0.go", []string{}},
 			"one mutation": {"source.1.go", []string{
 				"source.1.mut.1.go",
 			}},

--- a/viruses/cancelnil/testdata/source.0.go
+++ b/viruses/cancelnil/testdata/source.0.go
@@ -1,0 +1,3 @@
+//go:build testdata
+
+package source

--- a/viruses/cancelnil/testdata/source.1.go
+++ b/viruses/cancelnil/testdata/source.1.go
@@ -1,0 +1,12 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.DeadlineExceeded)
+}

--- a/viruses/cancelnil/testdata/source.1.mut.1.go
+++ b/viruses/cancelnil/testdata/source.1.mut.1.go
@@ -1,0 +1,12 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+}

--- a/viruses/cancelnil/testdata/source.2.go
+++ b/viruses/cancelnil/testdata/source.2.go
@@ -1,0 +1,15 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(context.DeadlineExceeded)
+
+	_, cancel2 := context.WithCancelCause(context.Background())
+	defer cancel2(context.DeadlineExceeded)
+}

--- a/viruses/cancelnil/testdata/source.2.mut.1.go
+++ b/viruses/cancelnil/testdata/source.2.mut.1.go
@@ -1,0 +1,15 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(nil)
+
+	_, cancel2 := context.WithCancelCause(context.Background())
+	defer cancel2(context.DeadlineExceeded)
+}

--- a/viruses/cancelnil/testdata/source.2.mut.2.go
+++ b/viruses/cancelnil/testdata/source.2.mut.2.go
@@ -1,0 +1,15 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(context.DeadlineExceeded)
+
+	_, cancel2 := context.WithCancelCause(context.Background())
+	defer cancel2(nil)
+}

--- a/viruses/cancelnil/testdata/source.3.go
+++ b/viruses/cancelnil/testdata/source.3.go
@@ -1,0 +1,27 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(context.DeadlineExceeded)
+
+	_, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	_, cancel3 := context.WithCancelCause(context.Background())
+	defer cancel3(context.DeadlineExceeded)
+
+	_, cancel4 := context.WithCancel(context.Background())
+	defer cancel4()
+
+	_, cancel5 := context.WithCancelCause(context.Background())
+	defer cancel5(nil)
+
+	_, cancel6 := context.WithCancelCause(context.Background())
+	defer cancel6(context.DeadlineExceeded)
+}

--- a/viruses/cancelnil/testdata/source.3.mut.1.go
+++ b/viruses/cancelnil/testdata/source.3.mut.1.go
@@ -1,0 +1,27 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(nil)
+
+	_, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	_, cancel3 := context.WithCancelCause(context.Background())
+	defer cancel3(context.DeadlineExceeded)
+
+	_, cancel4 := context.WithCancel(context.Background())
+	defer cancel4()
+
+	_, cancel5 := context.WithCancelCause(context.Background())
+	defer cancel5(nil)
+
+	_, cancel6 := context.WithCancelCause(context.Background())
+	defer cancel6(context.DeadlineExceeded)
+}

--- a/viruses/cancelnil/testdata/source.3.mut.2.go
+++ b/viruses/cancelnil/testdata/source.3.mut.2.go
@@ -1,0 +1,27 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(context.DeadlineExceeded)
+
+	_, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	_, cancel3 := context.WithCancelCause(context.Background())
+	defer cancel3(nil)
+
+	_, cancel4 := context.WithCancel(context.Background())
+	defer cancel4()
+
+	_, cancel5 := context.WithCancelCause(context.Background())
+	defer cancel5(nil)
+
+	_, cancel6 := context.WithCancelCause(context.Background())
+	defer cancel6(context.DeadlineExceeded)
+}

--- a/viruses/cancelnil/testdata/source.3.mut.3.go
+++ b/viruses/cancelnil/testdata/source.3.mut.3.go
@@ -1,0 +1,27 @@
+//go:build testdata
+
+package source
+
+import (
+	"context"
+)
+
+func f() {
+	_, cancel1 := context.WithCancelCause(context.Background())
+	defer cancel1(context.DeadlineExceeded)
+
+	_, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	_, cancel3 := context.WithCancelCause(context.Background())
+	defer cancel3(context.DeadlineExceeded)
+
+	_, cancel4 := context.WithCancel(context.Background())
+	defer cancel4()
+
+	_, cancel5 := context.WithCancelCause(context.Background())
+	defer cancel5(nil)
+
+	_, cancel6 := context.WithCancelCause(context.Background())
+	defer cancel6(nil)
+}


### PR DESCRIPTION
This PR adds `CancelNil`: A virus that mutates calls to `cancel(err)` (`cancel` being a `context.CancelCauseFunc`) with a non-nill `err` into `cancel(nil)`. These mutations should survive if tests do not properly check a context's cause of cancelation.