### PR TITLE
package importer changed from default to source

### DIFF
--- a/internal/gosourcefile/gosourcefile.go
+++ b/internal/gosourcefile/gosourcefile.go
@@ -33,7 +33,7 @@ func (f *GoSourceFile) Incubate(virus viruses.Virus) []*goinfectedfile.GoInfecte
 	}
 
 	cfg := types.Config{ //nolint:exhaustruct // default values for missing fields are okay
-		Importer: importer.Default(),
+		Importer: importer.ForCompiler(token.NewFileSet(), "source", nil),
 	}
 
 	info := types.Info{ //nolint:exhaustruct // Info.TypeOf needs Defs, Uses, and Types populated, we don't need the rest


### PR DESCRIPTION
There was a problem when working with project located in private repository. Default importer usage caused panic after checking file error because of unability to import from private repo. Changing importer from Default to source fixes the problem.