### PR TITLE
IgnoreSourceFiles now accepts multiple patterns

### DIFF
--- a/internal/ignoredrepository/ignoredrepository.go
+++ b/internal/ignoredrepository/ignoredrepository.go
@@ -8,13 +8,13 @@ import (
 )
 
 type FilteredRepository struct {
-	pattern  *regexp.Regexp
+	patterns []*regexp.Regexp
 	delegate ooze.Repository
 }
 
-func New(pattern *regexp.Regexp, delegate ooze.Repository) *FilteredRepository {
+func New(patterns []*regexp.Regexp, delegate ooze.Repository) *FilteredRepository {
 	return &FilteredRepository{
-		pattern:  pattern,
+		patterns: patterns,
 		delegate: delegate,
 	}
 }
@@ -22,10 +22,14 @@ func New(pattern *regexp.Regexp, delegate ooze.Repository) *FilteredRepository {
 func (r *FilteredRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 	filtered := []*gosourcefile.GoSourceFile{}
 
+FILE_LOOP:
 	for _, file := range r.delegate.ListGoSourceFiles() {
-		if !r.pattern.MatchString(file.String()) {
-			filtered = append(filtered, file)
+		for _, pattern := range r.patterns {
+			if pattern.MatchString(file.String()) {
+				continue FILE_LOOP
+			}
 		}
+		filtered = append(filtered, file)
 	}
 
 	return filtered

--- a/options.go
+++ b/options.go
@@ -15,13 +15,13 @@ import (
 type Option func(Options) Options
 
 type Options struct {
-	Repository               ooze.Repository
-	TestRunner               laboratory.TestRunner
-	TemporaryDir             laboratory.TemporaryDirectory
-	MinimumThreshold         float32
-	Parallel                 bool
-	IgnoreSourceFilesPattern *regexp.Regexp
-	Viruses                  []viruses.Virus
+	Repository                ooze.Repository
+	TestRunner                laboratory.TestRunner
+	TemporaryDir              laboratory.TemporaryDirectory
+	MinimumThreshold          float32
+	Parallel                  bool
+	IgnoreSourceFilesPatterns []*regexp.Regexp
+	Viruses                   []viruses.Virus
 }
 
 // WithRepositoryRoot configures which directory is the repository root. This is
@@ -70,11 +70,13 @@ func Parallel() func(Options) Options {
 	}
 }
 
-// IgnoreSourceFiles configures a regular expression representing source files
+// IgnoreSourceFiles configures a egular expressions representing source files
 // to be filtered out and not suffer any mutations.
-func IgnoreSourceFiles(pattern string) func(Options) Options {
+func IgnoreSourceFiles(patterns ...string) func(Options) Options {
 	return func(options Options) Options {
-		options.IgnoreSourceFilesPattern = regexp.MustCompile(pattern)
+		for _, pattern := range patterns {
+			options.IgnoreSourceFilesPatterns = append(options.IgnoreSourceFilesPatterns, regexp.MustCompile(pattern))
+		}
 
 		return options
 	}

--- a/options.go
+++ b/options.go
@@ -70,7 +70,7 @@ func Parallel() func(Options) Options {
 	}
 }
 
-// IgnoreSourceFiles configures a egular expressions representing source files
+// IgnoreSourceFiles configures regular expressions representing source files
 // to be filtered out and not suffer any mutations.
 func IgnoreSourceFiles(patterns ...string) func(Options) Options {
 	return func(options Options) Options {

--- a/options_test.go
+++ b/options_test.go
@@ -51,12 +51,12 @@ func TestOptions(t *testing.T) {
 	t.Run("can configure source files to ignore", func(t *testing.T) {
 		{
 			options := ooze.IgnoreSourceFiles(".*")(ooze.Options{})
-			assert.Equal(t, regexp.MustCompile(".*"), options.IgnoreSourceFilesPattern)
+			assert.Equal(t, []*regexp.Regexp{regexp.MustCompile(".*")}, options.IgnoreSourceFilesPatterns)
 		}
 
 		{
 			options := ooze.IgnoreSourceFiles(`.*\.go`)(ooze.Options{})
-			assert.Equal(t, regexp.MustCompile(`.*\.go`), options.IgnoreSourceFilesPattern)
+			assert.Equal(t, []*regexp.Regexp{regexp.MustCompile(`.*\.go`)}, options.IgnoreSourceFilesPatterns)
 		}
 	})
 

--- a/release.go
+++ b/release.go
@@ -47,12 +47,12 @@ func init() { //nolint:gochecknoinits
 }
 
 var defaultOptions = Options{ //nolint:gochecknoglobals
-	Repository:               fsrepository.New("."),
-	TestRunner:               cmdtestrunner.New("go", "test", "-count=1", "./..."),
-	TemporaryDir:             fstemporarydir.New("ooze-"),
-	MinimumThreshold:         1.0,
-	Parallel:                 false,
-	IgnoreSourceFilesPattern: nil,
+	Repository:                fsrepository.New("."),
+	TestRunner:                cmdtestrunner.New("go", "test", "-count=1", "./..."),
+	TemporaryDir:              fstemporarydir.New("ooze-"),
+	MinimumThreshold:          1.0,
+	Parallel:                  false,
+	IgnoreSourceFilesPatterns: nil,
 	Viruses: []viruses.Virus{
 		arithmetic.New(),
 		arithmeticassignment.New(),
@@ -108,8 +108,8 @@ func Release(t *testing.T, options ...Option) {
 		opts.MinimumThreshold,
 	)
 
-	if opts.IgnoreSourceFilesPattern != nil {
-		opts.Repository = ignoredrepository.New(opts.IgnoreSourceFilesPattern, opts.Repository)
+	if opts.IgnoreSourceFilesPatterns != nil {
+		opts.Repository = ignoredrepository.New(opts.IgnoreSourceFilesPatterns, opts.Repository)
 	}
 
 	if verbose() {


### PR DESCRIPTION
If at least one pattern matches, the files are filtered.

Fixes #14