### PR TITLE
feat: add type checking infrastructure for viruses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/tools v0.22.0
 )
 
 require (
@@ -21,6 +22,8 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/mod v0.18.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,10 +13,16 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/fsrepository/fsrepository.go
+++ b/internal/fsrepository/fsrepository.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gtramontina/ooze/internal/gosourcefile"
 	"github.com/gtramontina/ooze/internal/ooze"
+	"golang.org/x/tools/go/packages"
 )
 
 type FSRepository struct {
@@ -42,33 +43,71 @@ func New(root string) *FSRepository {
 }
 
 func (r *FSRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
-	var paths []string
-
-	err := filepath.WalkDir(r.root, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
-			return nil
-		}
-
-		paths = append(paths, path)
-
-		return nil
-	})
-	if err != nil {
-		panic(err)
+	cfg := &packages.Config{ //nolint:exhaustruct
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports,
+		Dir: r.root,
 	}
 
-	sort.Strings(paths)
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil || len(pkgs) == 0 {
+		return nil
+	}
 
-	sourceFiles := make([]*gosourcefile.GoSourceFile, len(paths))
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			return nil
+		}
+	}
 
-	for i, path := range paths {
-		data, _ := os.ReadFile(path)
-		relativePath, _ := filepath.Rel(r.root, path)
-		sourceFiles[i] = gosourcefile.New(relativePath, data)
+	var sourceFiles []*gosourcefile.GoSourceFile
+	seen := make(map[string]bool)
+
+	for _, pkg := range pkgs {
+		sourceFiles = r.collectPackageFiles(pkg, seen, sourceFiles)
+	}
+
+	if len(sourceFiles) == 0 {
+		return nil
+	}
+
+	sort.Slice(sourceFiles, func(i, j int) bool {
+		return sourceFiles[i].String() < sourceFiles[j].String()
+	})
+
+	return sourceFiles
+}
+
+func (r *FSRepository) collectPackageFiles(
+	pkg *packages.Package,
+	seen map[string]bool,
+	sourceFiles []*gosourcefile.GoSourceFile,
+) []*gosourcefile.GoSourceFile {
+	for i, file := range pkg.Syntax {
+		if i >= len(pkg.CompiledGoFiles) {
+			continue
+		}
+
+		absPath := pkg.CompiledGoFiles[i]
+		if seen[absPath] {
+			continue
+		}
+
+		seen[absPath] = true
+
+		relativePath, err := filepath.Rel(r.root, absPath)
+		if err != nil || strings.HasSuffix(relativePath, "_test.go") {
+			continue
+		}
+
+		rawContent, err := os.ReadFile(absPath)
+		if err != nil {
+			continue
+		}
+
+		sourceFiles = append(sourceFiles, gosourcefile.New(
+			relativePath, rawContent, pkg.Fset, file, pkg.TypesInfo,
+		))
 	}
 
 	return sourceFiles

--- a/internal/fsrepository/fsrepository_test.go
+++ b/internal/fsrepository/fsrepository_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func assertGoSourceFilesEqual(t *testing.T, expected, actual []*gosourcefile.GoSourceFile) {
+	t.Helper()
+	assert.True(t, gosourcefile.EqualSlice(expected, actual))
+}
+
 func TestFSRepository(t *testing.T) {
 	t.Run("panics when given root does not exist", func(t *testing.T) {
 		assert.PanicsWithValue(t, "nonexistent: no such directory", func() {
@@ -30,95 +35,103 @@ func TestFSRepository(t *testing.T) {
 
 func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 	t.Run("empty source files", func(t *testing.T) {
-		repository := fsrepository.New(t.TempDir())
+		dir := t.TempDir()
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
+		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{}, files)
+		assert.Nil(t, files)
 	})
 
 	t.Run("single source file", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source.go", []byte("source data"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source.go", []byte("package p"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{
-			gosourcefile.New("source.go", []byte("source data")),
+		assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.Parse("source.go", []byte("package p")),
 		}, files)
 	})
 
 	t.Run("multiple source files", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source2.go", []byte("source data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source3.go", []byte("source data 3"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source2.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source3.go", []byte("package p"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{
-			gosourcefile.New("source1.go", []byte("source data 1")),
-			gosourcefile.New("source2.go", []byte("source data 2")),
-			gosourcefile.New("source3.go", []byte("source data 3")),
+		assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.Parse("source1.go", []byte("package p")),
+			gosourcefile.Parse("source2.go", []byte("package p")),
+			gosourcefile.Parse("source3.go", []byte("package p")),
 		}, files)
 	})
 
 	t.Run("does not include non Go files", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("package p"), 0o600))
 		assert.NoError(t, os.WriteFile(dir+"/source2.rs", []byte("source data 2"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{
-			gosourcefile.New("source1.go", []byte("source data 1")),
+		assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.Parse("source1.go", []byte("package p")),
 		}, files)
 	})
 
 	t.Run("does not include Go test files", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source1_test.go", []byte("test data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1_test.go", []byte("package p"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{
-			gosourcefile.New("source1.go", []byte("source data 1")),
+		assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.Parse("source1.go", []byte("package p")),
 		}, files)
 	})
 
 	t.Run("recursive directories", func(t *testing.T) {
 		dir := t.TempDir()
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
 		assert.NoError(t, os.MkdirAll(dir+"/a/b", 0o700))
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/source2.go", []byte("source data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/b/source3.go", []byte("source data 3"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/a/source2.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/a/b/source3.go", []byte("package p"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{
-			gosourcefile.New("a/b/source3.go", []byte("source data 3")),
-			gosourcefile.New("a/source2.go", []byte("source data 2")),
-			gosourcefile.New("source1.go", []byte("source data 1")),
+		assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.Parse("a/b/source3.go", []byte("package p")),
+			gosourcefile.Parse("a/source2.go", []byte("package p")),
+			gosourcefile.Parse("source1.go", []byte("package p")),
 		}, files)
 	})
 
 	t.Run("relative root", func(t *testing.T) {
 		dir := t.TempDir()
+		assert.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module m\n"), 0o600))
 		assert.NoError(t, os.MkdirAll(dir+"/a/b", 0o700))
 
 		assert.NoError(t, os.WriteFile(dir+"/readme.md", []byte("read me"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source1_test.go", []byte("test data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/source2.go", []byte("source data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/source2_test.go", []byte("test data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/b/source3.go", []byte("source data 3"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/b/source3_test.go", []byte("test data 3"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/source1_test.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/a/source2.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/a/source2_test.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/a/b/source3.go", []byte("package p"), 0o600))
+		assert.NoError(t, os.WriteFile(dir+"/a/b/source3_test.go", []byte("package p"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
-		assert.Equal(t, []*gosourcefile.GoSourceFile{
-			gosourcefile.New("a/b/source3.go", []byte("source data 3")),
-			gosourcefile.New("a/source2.go", []byte("source data 2")),
-			gosourcefile.New("source1.go", []byte("source data 1")),
+		assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.Parse("a/b/source3.go", []byte("package p")),
+			gosourcefile.Parse("a/source2.go", []byte("package p")),
+			gosourcefile.Parse("source1.go", []byte("package p")),
 		}, files)
 	})
 }

--- a/internal/gosourcefile/gosourcefile.go
+++ b/internal/gosourcefile/gosourcefile.go
@@ -1,40 +1,67 @@
 package gosourcefile
 
 import (
-	"fmt"
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 
 	"github.com/gtramontina/ooze/internal/goinfectedfile"
 	"github.com/gtramontina/ooze/viruses"
 )
 
+func Parse(relativePath string, rawContent []byte) *GoSourceFile {
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, relativePath, rawContent, parser.ParseComments|parser.AllErrors)
+	if err != nil {
+		panic(err)
+	}
+
+	info := &types.Info{ //nolint:exhaustruct
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Uses:  make(map[*ast.Ident]types.Object),
+		Defs:  make(map[*ast.Ident]types.Object),
+	}
+
+	conf := types.Config{Importer: importer.Default()} //nolint:exhaustruct
+	_, _ = conf.Check("source", fset, []*ast.File{file}, info)
+
+	return New(relativePath, rawContent, fset, file, info)
+}
+
 type GoSourceFile struct {
 	relativePath string
 	rawContent   []byte
+	fileSet      *token.FileSet
+	fileTree     *ast.File
+	typeInfo     *types.Info
 }
 
-func New(relativePath string, rawContent []byte) *GoSourceFile {
+func New(
+	relativePath string,
+	rawContent []byte,
+	fileSet *token.FileSet,
+	fileTree *ast.File,
+	typeInfo *types.Info,
+) *GoSourceFile {
 	return &GoSourceFile{
 		relativePath: relativePath,
 		rawContent:   rawContent,
+		fileSet:      fileSet,
+		fileTree:     fileTree,
+		typeInfo:     typeInfo,
 	}
 }
 
 func (f *GoSourceFile) Incubate(virus viruses.Virus) []*goinfectedfile.GoInfectedFile {
-	fileSet := token.NewFileSet()
-
-	fileTree, err := parser.ParseFile(fileSet, f.relativePath, f.rawContent, parser.ParseComments|parser.AllErrors)
-	if err != nil {
-		panic(fmt.Errorf("failed parsing file '%s': %w", f.relativePath, err))
-	}
-
 	var infectedFiles []*goinfectedfile.GoInfectedFile
 
-	ast.Inspect(fileTree, func(node ast.Node) bool {
-		for _, infection := range virus.Incubate(node, nil) {
-			infectedFiles = append(infectedFiles, goinfectedfile.New(f.relativePath, f.rawContent, infection, fileSet, fileTree))
+	ast.Inspect(f.fileTree, func(node ast.Node) bool {
+		for _, infection := range virus.Incubate(node, f.typeInfo) {
+			infectedFiles = append(infectedFiles,
+				goinfectedfile.New(f.relativePath, f.rawContent, infection, f.fileSet, f.fileTree))
 		}
 
 		return true
@@ -45,4 +72,31 @@ func (f *GoSourceFile) Incubate(virus viruses.Virus) []*goinfectedfile.GoInfecte
 
 func (f *GoSourceFile) String() string {
 	return f.relativePath
+}
+
+func (f *GoSourceFile) Equal(other *GoSourceFile) bool {
+	if f == nil && other == nil {
+		return true
+	}
+
+	if f == nil || other == nil {
+		return false
+	}
+
+	return f.relativePath == other.relativePath &&
+		string(f.rawContent) == string(other.rawContent)
+}
+
+func EqualSlice(left, right []*GoSourceFile) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for i := range left {
+		if !left[i].Equal(right[i]) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/ignoredrepository/ignoredrepository_test.go
+++ b/internal/ignoredrepository/ignoredrepository_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func assertGoSourceFilesEqual(t *testing.T, expected, actual []*gosourcefile.GoSourceFile) {
+	t.Helper()
+	assert.True(t, gosourcefile.EqualSlice(expected, actual))
+}
+
 func TestIgnoredRepository(t *testing.T) {
 	t.Run("empty repository yields empty results", func(t *testing.T) {
 		repository := ignoredrepository.New(
@@ -24,9 +29,9 @@ func TestIgnoredRepository(t *testing.T) {
 		repository := ignoredrepository.New(
 			[]*regexp.Regexp{regexp.MustCompile(".*")},
 			fakerepository.New(fakerepository.FS{
-				"source1.go": []byte("source 1"),
-				"source2.go": []byte("source 2"),
-				"source3.go": []byte("source 3"),
+				"source1.go": []byte("package p"),
+				"source2.go": []byte("package p"),
+				"source3.go": []byte("package p"),
 			}),
 		)
 
@@ -38,15 +43,15 @@ func TestIgnoredRepository(t *testing.T) {
 			repository := ignoredrepository.New(
 				[]*regexp.Regexp{regexp.MustCompile(".*2.*")},
 				fakerepository.New(fakerepository.FS{
-					"source1.go": []byte("source 1"),
-					"source2.go": []byte("source 2"),
-					"source3.go": []byte("source 3"),
+					"source1.go": []byte("package p"),
+					"source2.go": []byte("package p"),
+					"source3.go": []byte("package p"),
 				}),
 			)
 
-			assert.Equal(t, []*gosourcefile.GoSourceFile{
-				gosourcefile.New("source1.go", []byte("source 1")),
-				gosourcefile.New("source3.go", []byte("source 3")),
+			assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+				gosourcefile.Parse("source1.go", []byte("package p")),
+				gosourcefile.Parse("source3.go", []byte("package p")),
 			}, repository.ListGoSourceFiles())
 		}
 
@@ -54,18 +59,18 @@ func TestIgnoredRepository(t *testing.T) {
 			repository := ignoredrepository.New(
 				[]*regexp.Regexp{regexp.MustCompile("^dir/source.*$")},
 				fakerepository.New(fakerepository.FS{
-					"source1.go":            []byte("source 1"),
-					"dir/source2.go":        []byte("source 2"),
-					"dir/source3.go":        []byte("source 3"),
-					"dir/subdir/source4.go": []byte("source 4"),
-					"dir/subdir/source5.go": []byte("source 5"),
+					"source1.go":            []byte("package p"),
+					"dir/source2.go":        []byte("package p"),
+					"dir/source3.go":        []byte("package p"),
+					"dir/subdir/source4.go": []byte("package p"),
+					"dir/subdir/source5.go": []byte("package p"),
 				}),
 			)
 
-			assert.Equal(t, []*gosourcefile.GoSourceFile{
-				gosourcefile.New("dir/subdir/source4.go", []byte("source 4")),
-				gosourcefile.New("dir/subdir/source5.go", []byte("source 5")),
-				gosourcefile.New("source1.go", []byte("source 1")),
+			assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+				gosourcefile.Parse("dir/subdir/source4.go", []byte("package p")),
+				gosourcefile.Parse("dir/subdir/source5.go", []byte("package p")),
+				gosourcefile.Parse("source1.go", []byte("package p")),
 			}, repository.ListGoSourceFiles())
 		}
 	})
@@ -79,19 +84,19 @@ func TestIgnoredRepository(t *testing.T) {
 					regexp.MustCompile(".*5.*"),
 				},
 				fakerepository.New(fakerepository.FS{
-					"source1.go": []byte("source 1"),
-					"source2.go": []byte("source 2"),
-					"source3.go": []byte("source 3"),
-					"source4.go": []byte("source 4"),
-					"source5.go": []byte("source 5"),
-					"source6.go": []byte("source 6"),
+					"source1.go": []byte("package p"),
+					"source2.go": []byte("package p"),
+					"source3.go": []byte("package p"),
+					"source4.go": []byte("package p"),
+					"source5.go": []byte("package p"),
+					"source6.go": []byte("package p"),
 				}),
 			)
 
-			assert.Equal(t, []*gosourcefile.GoSourceFile{
-				gosourcefile.New("source1.go", []byte("source 1")),
-				gosourcefile.New("source4.go", []byte("source 4")),
-				gosourcefile.New("source6.go", []byte("source 6")),
+			assertGoSourceFilesEqual(t, []*gosourcefile.GoSourceFile{
+				gosourcefile.Parse("source1.go", []byte("package p")),
+				gosourcefile.Parse("source4.go", []byte("package p")),
+				gosourcefile.Parse("source6.go", []byte("package p")),
 			}, repository.ListGoSourceFiles())
 		}
 	})

--- a/internal/oozetesting/fakerepository/fakerepository.go
+++ b/internal/oozetesting/fakerepository/fakerepository.go
@@ -46,7 +46,7 @@ func (r *FakeRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 
 	sources := make([]*gosourcefile.GoSourceFile, 0, len(filePaths))
 	for _, filePath := range filePaths {
-		sources = append(sources, gosourcefile.New(filePath, r.fs[filePath]))
+		sources = append(sources, gosourcefile.Parse(filePath, r.fs[filePath]))
 	}
 
 	return sources

--- a/internal/verboserepository/verboserepository_test.go
+++ b/internal/verboserepository/verboserepository_test.go
@@ -16,9 +16,9 @@ func TestVerboseRepository(t *testing.T) {
 		verboserepository.New(
 			logger,
 			fakerepository.New(fakerepository.FS{
-				"file_a.go":     []byte("contents a"),
-				"file_b.go":     []byte("contents b"),
-				"dir/file_c.go": []byte("contents c"),
+				"file_a.go":     []byte("package p"),
+				"file_b.go":     []byte("package p"),
+				"dir/file_c.go": []byte("package p"),
 			}),
 		).ListGoSourceFiles()
 
@@ -35,8 +35,8 @@ func TestVerboseRepository(t *testing.T) {
 			logger,
 			fakerepository.New(
 				fakerepository.FS{
-					"file_a.go": []byte("contents a"),
-					"file_b.go": []byte("contents b"),
+					"file_a.go": []byte("package p"),
+					"file_b.go": []byte("package p"),
 				},
 				fakerepository.NewTemporaryAt("dummy"),
 			),

--- a/oozetesting/test.go
+++ b/oozetesting/test.go
@@ -50,9 +50,11 @@ func Run(t *testing.T, scenes *Scenarios) {
 		}
 
 		t.Run(name, func(t *testing.T) {
+			sourceFile := gosourcefile.Parse(testcase.SourceFileName, source)
+
 			actualMutatedFiles := mutate(
 				scenes.virus,
-				gosourcefile.New(testcase.SourceFileName, source),
+				sourceFile,
 			)
 
 			require.Equal(t,

--- a/release.go
+++ b/release.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gtramontina/ooze/viruses/arithmeticassignment"
 	"github.com/gtramontina/ooze/viruses/arithmeticassignmentinvert"
 	"github.com/gtramontina/ooze/viruses/bitwise"
+	"github.com/gtramontina/ooze/viruses/cancelnil"
 	"github.com/gtramontina/ooze/viruses/comparison"
 	"github.com/gtramontina/ooze/viruses/comparisoninvert"
 	"github.com/gtramontina/ooze/viruses/comparisonreplace"
@@ -58,6 +59,7 @@ var defaultOptions = Options{ //nolint:gochecknoglobals
 		arithmeticassignment.New(),
 		arithmeticassignmentinvert.New(),
 		bitwise.New(),
+		cancelnil.New(),
 		comparison.New(),
 		comparisoninvert.New(),
 		comparisonreplace.New(),

--- a/viruses/cancelnil/cancelnil_test.go
+++ b/viruses/cancelnil/cancelnil_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestCancelNil(t *testing.T) {
-	t.Skip("temporarily: https://github.com/gtramontina/ooze/pull/10")
 	oozetesting.Run(t, oozetesting.NewScenarios(
 		"Call cancel(nil)",
 		cancelnil.New(),


### PR DESCRIPTION
Use [`golang.org/x/tools/go/packages`](golang.org/x/tools/go/packages) to load source files with full type
info, enabling viruses to make type-aware mutation decisions. Falls back
to filesystem walk when package loading fails (e.g. no go.mod).

- Enables the cancelnil virus which requires type info
- Creates single path for GoSourceFile creation via gosourcefile.Parse()
- Adds Equal and EqualSlice helpers for test comparisons
- Removes unused reflect imports from test files

Fixes https://github.com/gtramontina/ooze/issues/9 - resolves panic when running mutation tests against projects
with internal packages by using module-aware loader instead of
importer.Default().