### PR TITLE
fix: support Windows and macOS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.go text eol=lf

--- a/.github/workflows/os-compatibility.yml
+++ b/.github/workflows/os-compatibility.yml
@@ -1,0 +1,52 @@
+name: "🖥️ OS Compatibility"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    env:
+      GOTOOLCHAIN: local
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 24.04
+            runner: ubuntu-24.04
+          - name: macOS 26
+            runner: macos-26
+          - name: Windows 2025
+            runner: windows-2025
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go 1.26.6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.6"
+          cache: true
+
+      - name: Report Go version
+        run: go version
+
+      - name: Test
+        run: go test -race -cover -timeout=60s -shuffle=on ./...
+
+  required:
+    name: OS Compatibility
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify supported operating systems
+        run: test "${{ needs.test.result }}" = "success"

--- a/internal/cmdtestrunner/cmdtestrunner_test.go
+++ b/internal/cmdtestrunner/cmdtestrunner_test.go
@@ -1,47 +1,86 @@
 package cmdtestrunner_test
 
 import (
-	"path"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gtramontina/ooze/internal/cmdtestrunner"
 	"github.com/gtramontina/ooze/internal/oozetesting/fakerepository"
 	"github.com/gtramontina/ooze/internal/result"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const helperProcessModeEnvironmentVariable = "OOZE_CMDTESTRUNNER_TEST_HELPER_MODE"
+
+func TestMain(m *testing.M) {
+	switch os.Getenv(helperProcessModeEnvironmentVariable) {
+	case "fail":
+		_, _ = os.Stdout.WriteString("tests failed")
+		os.Exit(1)
+	case "pass":
+		_, _ = os.Stdout.WriteString("tests passed")
+		os.Exit(0)
+	case "working-directory":
+		_, err := os.Stat("working-directory-marker")
+		if err != nil {
+			os.Exit(2)
+		}
+
+		_, _ = os.Stdout.WriteString("marker found")
+		os.Exit(0)
+	case "environment":
+		_, _ = os.Stdout.WriteString(os.Getenv("TEST_VAR"))
+		os.Exit(0)
+	default:
+		os.Exit(m.Run())
+	}
+}
 
 func TestCMDTestRunner(t *testing.T) {
 	t.Run("has a positive result when subprocess exists unsuccessfully", func(t *testing.T) {
 		temporaryRepository := fakerepository.NewTemporaryAt(t.TempDir())
 
-		output := cmdtestrunner.New("sh", "-c", "printf 'tests failed'; exit 1").Test(temporaryRepository)
+		output := newHelperCommand(t, "fail").Test(temporaryRepository)
 		assert.Equal(t, result.Ok("tests failed"), output)
 	})
 
 	t.Run("has a negative result when subprocess exists successfully", func(t *testing.T) {
 		temporaryRepository := fakerepository.NewTemporaryAt(t.TempDir())
 
-		output := cmdtestrunner.New("sh", "-c", "printf 'tests passed'; exit 0").Test(temporaryRepository)
+		output := newHelperCommand(t, "pass").Test(temporaryRepository)
 		assert.Equal(t, result.Err[string]("tests passed"), output)
 	})
 
 	t.Run("runs within the given directory context", func(t *testing.T) {
 		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "working-directory-marker"), nil, 0o600))
 		temporaryRepository := fakerepository.NewTemporaryAt(dir)
 
-		output := cmdtestrunner.New("sh", "-c", "basename $(pwd)").Test(temporaryRepository)
-		assert.Equal(t, result.Err[string](path.Base(dir)+"\n"), output)
+		output := newHelperCommand(t, "working-directory").Test(temporaryRepository)
+		assert.Equal(t, result.Err[string]("marker found"), output)
 	})
 
 	t.Run("makes all environment variables available to the subprocess", func(t *testing.T) {
 		temporaryRepository := fakerepository.NewTemporaryAt(t.TempDir())
 
-		t.Setenv("TEST_VAR_1", "test_value_1")
-		output := cmdtestrunner.New("sh", "-c", "printf $TEST_VAR_1").Test(temporaryRepository)
+		t.Setenv("TEST_VAR", "test_value_1")
+		output := newHelperCommand(t, "environment").Test(temporaryRepository)
 		assert.Equal(t, result.Err[string]("test_value_1"), output)
 
-		t.Setenv("TEST_VAR_2", "test_value_2")
-		output = cmdtestrunner.New("sh", "-c", "printf $TEST_VAR_2").Test(temporaryRepository)
+		t.Setenv("TEST_VAR", "test_value_2")
+		output = newHelperCommand(t, "environment").Test(temporaryRepository)
 		assert.Equal(t, result.Err[string]("test_value_2"), output)
 	})
+}
+
+func newHelperCommand(t *testing.T, mode string) *cmdtestrunner.CMDTestRunner {
+	t.Helper()
+
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	t.Setenv(helperProcessModeEnvironmentVariable, mode)
+
+	return cmdtestrunner.New(executable)
 }

--- a/internal/fsrepository/fsrepository.go
+++ b/internal/fsrepository/fsrepository.go
@@ -74,7 +74,7 @@ func (r *FSRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 	return sourceFiles
 }
 
-func (r *FSRepository) LinkAllToTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
+func (r *FSRepository) MaterializeTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
 	rootSize := len(strings.Split(r.root, string(os.PathSeparator)))
 
 	err := filepath.WalkDir(r.root, func(path string, entry fs.DirEntry, err error) error {

--- a/internal/fsrepository/fsrepository.go
+++ b/internal/fsrepository/fsrepository.go
@@ -65,18 +65,19 @@ func (r *FSRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 
 	sourceFiles := make([]*gosourcefile.GoSourceFile, len(paths))
 
-	for i, path := range paths {
-		data, _ := os.ReadFile(path)
-		relativePath, _ := filepath.Rel(r.root, path)
-		sourceFiles[i] = gosourcefile.New(relativePath, data)
+	for index, filePath := range paths {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			panic(fmt.Errorf("failed reading source file '%s': %w", filePath, err))
+		}
+
+		sourceFiles[index] = gosourcefile.New(r.logicalPath(filePath), data)
 	}
 
 	return sourceFiles
 }
 
 func (r *FSRepository) MaterializeTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
-	rootSize := len(strings.Split(r.root, string(os.PathSeparator)))
-
 	err := filepath.WalkDir(r.root, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -86,20 +87,20 @@ func (r *FSRepository) MaterializeTemporaryRepository(temporaryPath string) ooze
 			return err
 		}
 
-		absolutePath, err := filepath.Abs(path)
+		relativePath, err := filepath.Rel(r.root, path)
 		if err != nil {
-			return fmt.Errorf("failed getting absolute path for '%s': %w", path, err)
+			return fmt.Errorf("failed getting path relative to '%s' for '%s': %w", r.root, path, err)
 		}
 
-		linkPath := filepath.Join(temporaryPath, filepath.Join(strings.Split(path, string(os.PathSeparator))[rootSize:]...))
-		err = os.MkdirAll(filepath.Dir(linkPath), os.ModePerm)
+		materializedPath := filepath.Join(temporaryPath, relativePath)
+		err = os.MkdirAll(filepath.Dir(materializedPath), os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("failed creating directory tree for '%s': %w", linkPath, err)
+			return fmt.Errorf("failed creating directory tree for '%s': %w", materializedPath, err)
 		}
 
-		err = os.Symlink(absolutePath, linkPath) //nolint:gosec // Trusted source path.
+		err = materializeFile(path, materializedPath)
 		if err != nil {
-			return fmt.Errorf("failed creating link from '%s' to '%s': %w", path, linkPath, err)
+			return fmt.Errorf("failed materializing '%s' at '%s': %w", path, materializedPath, err)
 		}
 
 		return nil
@@ -109,4 +110,13 @@ func (r *FSRepository) MaterializeTemporaryRepository(temporaryPath string) ooze
 	}
 
 	return NewTemporary(temporaryPath)
+}
+
+func (r *FSRepository) logicalPath(filePath string) string {
+	relativePath, err := filepath.Rel(r.root, filePath)
+	if err != nil {
+		panic(fmt.Errorf("failed resolving source path '%s' from root '%s': %w", filePath, r.root, err))
+	}
+
+	return filepath.ToSlash(relativePath)
 }

--- a/internal/fsrepository/fsrepository_materialization_unix_test.go
+++ b/internal/fsrepository/fsrepository_materialization_unix_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package fsrepository_test
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertMaterializedFile(t *testing.T, sourcePath, materializedPath string) {
+	t.Helper()
+
+	info, err := os.Lstat(materializedPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&fs.ModeSymlink)
+
+	sourceInfo, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+	materializedInfo, err := os.Stat(materializedPath)
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(sourceInfo, materializedInfo), "materialized file must link to its matching source")
+}

--- a/internal/fsrepository/fsrepository_materialization_windows_test.go
+++ b/internal/fsrepository/fsrepository_materialization_windows_test.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package fsrepository_test
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertMaterializedFile(t *testing.T, sourcePath, materializedPath string) {
+	t.Helper()
+
+	info, err := os.Lstat(materializedPath)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&fs.ModeSymlink, "Windows sandboxes must not require symlink privileges")
+
+	source, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	materialized, err := os.ReadFile(materializedPath)
+	require.NoError(t, err)
+	assert.Equal(t, source, materialized)
+}

--- a/internal/fsrepository/fsrepository_test.go
+++ b/internal/fsrepository/fsrepository_test.go
@@ -20,10 +20,11 @@ func TestFSRepository(t *testing.T) {
 
 	t.Run("panics when given root isn't a directory", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/not-a-dir", []byte("source data"), 0o600))
+		filePath := filepath.Join(dir, "not-a-dir")
+		assert.NoError(t, os.WriteFile(filePath, []byte("source data"), 0o600))
 
-		assert.PanicsWithValue(t, dir+"/not-a-dir: not a directory", func() {
-			fsrepository.New(dir + "/not-a-dir")
+		assert.PanicsWithValue(t, filePath+": not a directory", func() {
+			fsrepository.New(filePath)
 		})
 	})
 }
@@ -37,7 +38,7 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 	t.Run("single source file", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source.go", []byte("source data"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source.go"), []byte("source data"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
@@ -48,9 +49,9 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 	t.Run("multiple source files", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source2.go", []byte("source data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source3.go", []byte("source data 3"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1.go"), []byte("source data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source2.go"), []byte("source data 2"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source3.go"), []byte("source data 3"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
@@ -63,8 +64,8 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 	t.Run("does not include non Go files", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source2.rs", []byte("source data 2"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1.go"), []byte("source data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source2.rs"), []byte("source data 2"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
@@ -75,8 +76,8 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 	t.Run("does not include Go test files", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source1_test.go", []byte("test data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1.go"), []byte("source data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1_test.go"), []byte("test data 1"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
@@ -87,10 +88,10 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 	t.Run("recursive directories", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.MkdirAll(dir+"/a/b", 0o700))
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/source2.go", []byte("source data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/b/source3.go", []byte("source data 3"), 0o600))
+		assert.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o700))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1.go"), []byte("source data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "a", "source2.go"), []byte("source data 2"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "source3.go"), []byte("source data 3"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
@@ -103,15 +104,15 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 	t.Run("relative root", func(t *testing.T) {
 		dir := t.TempDir()
-		assert.NoError(t, os.MkdirAll(dir+"/a/b", 0o700))
+		assert.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o700))
 
-		assert.NoError(t, os.WriteFile(dir+"/readme.md", []byte("read me"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source1.go", []byte("source data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/source1_test.go", []byte("test data 1"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/source2.go", []byte("source data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/source2_test.go", []byte("test data 2"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/b/source3.go", []byte("source data 3"), 0o600))
-		assert.NoError(t, os.WriteFile(dir+"/a/b/source3_test.go", []byte("test data 3"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "readme.md"), []byte("read me"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1.go"), []byte("source data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "source1_test.go"), []byte("test data 1"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "a", "source2.go"), []byte("source data 2"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "a", "source2_test.go"), []byte("test data 2"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "source3.go"), []byte("source data 3"), 0o600))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "a", "b", "source3_test.go"), []byte("test data 3"), 0o600))
 
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
@@ -125,47 +126,61 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 
 func TestFSRepository_LinkAllToTemporaryRepository(t *testing.T) {
 	dir := t.TempDir()
-	assert.NoError(t, os.MkdirAll(dir+"/to-link/child_a/child_b", 0o700))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "to-link", "child_a", "child_b"), 0o700))
 
-	assert.NoError(t, os.MkdirAll(dir+"/to-link/child_a/child_b", 0o700))
-	assert.NoError(t, os.WriteFile(dir+"/to-link/readme.md", []byte(""), 0o600))
-	assert.NoError(t, os.WriteFile(dir+"/to-link/makefile", []byte(""), 0o600))
-	assert.NoError(t, os.WriteFile(dir+"/to-link/test_a.go", []byte(""), 0o600))
-	assert.NoError(t, os.WriteFile(dir+"/to-link/test_b.go", []byte(""), 0o600))
-	assert.NoError(t, os.WriteFile(dir+"/to-link/child_a/test_c.go", []byte(""), 0o600))
-	assert.NoError(t, os.WriteFile(dir+"/to-link/child_a/child_b/test_d.go", []byte(""), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "to-link", "readme.md"), []byte("readme"), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "to-link", "makefile"), []byte("makefile"), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "to-link", "test_a.go"), []byte("test a"), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "to-link", "test_b.go"), []byte("test b"), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "to-link", "child_a", "test_c.go"), []byte("test c"), 0o600))
+	nestedSourcePath := filepath.Join(dir, "to-link", "child_a", "child_b", "test_d.go")
+	assert.NoError(t, os.WriteFile(nestedSourcePath, []byte("test d"), 0o600))
 
-	repository := fsrepository.New(dir + "/to-link")
-	temporaryRepository := repository.LinkAllToTemporaryRepository(dir + "/linked")
+	sourceRoot := filepath.Join(dir, "to-link")
+	linkedRoot := filepath.Join(dir, "linked")
+	repository := fsrepository.New(sourceRoot)
+	temporaryRepository := repository.LinkAllToTemporaryRepository(linkedRoot)
 
 	t.Run("creates a link of all files recursively", func(t *testing.T) {
 		var files []string
-		err := filepath.WalkDir(dir+"/linked", func(path string, entry fs.DirEntry, err error) error {
+		err := filepath.WalkDir(linkedRoot, func(path string, entry fs.DirEntry, err error) error {
 			assert.NoError(t, err)
 			if entry.IsDir() {
 				return nil
 			}
 
-			info, err := entry.Info()
+			relativePath, err := filepath.Rel(linkedRoot, path)
 			assert.NoError(t, err)
-			assert.True(t, info.Mode()&fs.ModeSymlink != 0)
+			assertMaterializedFile(t, filepath.Join(sourceRoot, relativePath), path)
 
-			files = append(files, path)
+			files = append(files, filepath.ToSlash(relativePath))
 
 			return nil
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
-			dir + "/linked/child_a/child_b/test_d.go",
-			dir + "/linked/child_a/test_c.go",
-			dir + "/linked/makefile",
-			dir + "/linked/readme.md",
-			dir + "/linked/test_a.go",
-			dir + "/linked/test_b.go",
+			"child_a/child_b/test_d.go",
+			"child_a/test_c.go",
+			"makefile",
+			"readme.md",
+			"test_a.go",
+			"test_b.go",
 		}, files)
 	})
 
 	t.Run("results in a new temporary repository", func(t *testing.T) {
-		assert.Equal(t, fsrepository.NewTemporary(dir+"/linked"), temporaryRepository)
+		assert.Equal(t, fsrepository.NewTemporary(linkedRoot), temporaryRepository)
+	})
+
+	t.Run("isolates overwritten files from their sources", func(t *testing.T) {
+		temporaryRepository.Overwrite("test_a.go", []byte("mutated"))
+
+		materialized, err := os.ReadFile(filepath.Join(linkedRoot, "test_a.go"))
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("mutated"), materialized)
+
+		source, err := os.ReadFile(filepath.Join(sourceRoot, "test_a.go"))
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("test a"), source)
 	})
 }

--- a/internal/fsrepository/fsrepository_test.go
+++ b/internal/fsrepository/fsrepository_test.go
@@ -124,7 +124,7 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 	})
 }
 
-func TestFSRepository_LinkAllToTemporaryRepository(t *testing.T) {
+func TestFSRepository_MaterializeTemporaryRepository(t *testing.T) {
 	dir := t.TempDir()
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "to-link", "child_a", "child_b"), 0o700))
 
@@ -137,19 +137,19 @@ func TestFSRepository_LinkAllToTemporaryRepository(t *testing.T) {
 	assert.NoError(t, os.WriteFile(nestedSourcePath, []byte("test d"), 0o600))
 
 	sourceRoot := filepath.Join(dir, "to-link")
-	linkedRoot := filepath.Join(dir, "linked")
+	materializedRoot := filepath.Join(dir, "materialized")
 	repository := fsrepository.New(sourceRoot)
-	temporaryRepository := repository.LinkAllToTemporaryRepository(linkedRoot)
+	temporaryRepository := repository.MaterializeTemporaryRepository(materializedRoot)
 
-	t.Run("creates a link of all files recursively", func(t *testing.T) {
+	t.Run("materializes all files recursively", func(t *testing.T) {
 		var files []string
-		err := filepath.WalkDir(linkedRoot, func(path string, entry fs.DirEntry, err error) error {
+		err := filepath.WalkDir(materializedRoot, func(path string, entry fs.DirEntry, err error) error {
 			assert.NoError(t, err)
 			if entry.IsDir() {
 				return nil
 			}
 
-			relativePath, err := filepath.Rel(linkedRoot, path)
+			relativePath, err := filepath.Rel(materializedRoot, path)
 			assert.NoError(t, err)
 			assertMaterializedFile(t, filepath.Join(sourceRoot, relativePath), path)
 
@@ -169,13 +169,13 @@ func TestFSRepository_LinkAllToTemporaryRepository(t *testing.T) {
 	})
 
 	t.Run("results in a new temporary repository", func(t *testing.T) {
-		assert.Equal(t, fsrepository.NewTemporary(linkedRoot), temporaryRepository)
+		assert.Equal(t, fsrepository.NewTemporary(materializedRoot), temporaryRepository)
 	})
 
 	t.Run("isolates overwritten files from their sources", func(t *testing.T) {
 		temporaryRepository.Overwrite("test_a.go", []byte("mutated"))
 
-		materialized, err := os.ReadFile(filepath.Join(linkedRoot, "test_a.go"))
+		materialized, err := os.ReadFile(filepath.Join(materializedRoot, "test_a.go"))
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("mutated"), materialized)
 

--- a/internal/fsrepository/fstemporaryrepository.go
+++ b/internal/fsrepository/fstemporaryrepository.go
@@ -3,10 +3,9 @@ package fsrepository
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
-	"strings"
 )
 
 var (
@@ -44,21 +43,28 @@ func (r *FSTemporaryRepository) Overwrite(filePath string, data []byte) {
 		panic(errRemoved)
 	}
 
-	fullPath := path.Join(r.root, filePath)
-
-	if !strings.HasPrefix(fullPath, r.root) {
-		panic(fmt.Errorf("%w: resolved path '%s' does not belong to root '%s'", errNotAllowed, fullPath, r.root))
+	relativePath := filepath.Clean(filepath.FromSlash(filePath))
+	if relativePath == "." || !filepath.IsLocal(relativePath) {
+		panic(fmt.Errorf("%w: path '%s' does not identify a file within root '%s'", errNotAllowed, filePath, r.root))
 	}
 
-	_, statErr := os.Stat(fullPath)
+	root, err := os.OpenRoot(r.root)
+	if err != nil {
+		panic(fmt.Errorf("failed opening repository root '%s': %w", r.root, err))
+	}
+	defer func() { _ = root.Close() }()
+
+	_, statErr := root.Lstat(relativePath)
 	if statErr == nil {
-		removeErr := os.Remove(fullPath)
+		removeErr := root.Remove(relativePath)
 		if removeErr != nil {
 			panic(fmt.Errorf("failed removing existing file '%s': %w", filePath, removeErr))
 		}
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		panic(fmt.Errorf("failed inspecting file '%s': %w", filePath, statErr))
 	}
 
-	err := os.WriteFile(fullPath, data, os.ModePerm) //nolint:gosec
+	err = root.WriteFile(relativePath, data, os.ModePerm)
 	if err != nil {
 		panic(fmt.Errorf("failed writing data to file '%s', %w", filePath, err))
 	}

--- a/internal/fsrepository/fstemporaryrepository_test.go
+++ b/internal/fsrepository/fstemporaryrepository_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gtramontina/ooze/internal/fsrepository"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFSTemporaryRepository(t *testing.T) {
@@ -97,7 +98,7 @@ func TestFSTemporaryRepository(t *testing.T) {
 				})
 
 				info, err := os.Stat(dir)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.True(t, info.IsDir())
 			})
 		}

--- a/internal/fsrepository/fstemporaryrepository_test.go
+++ b/internal/fsrepository/fstemporaryrepository_test.go
@@ -2,7 +2,7 @@ package fsrepository_test
 
 import (
 	"os"
-	"syscall"
+	"path/filepath"
 	"testing"
 
 	"github.com/gtramontina/ooze/internal/fsrepository"
@@ -30,55 +30,77 @@ func TestFSTemporaryRepository(t *testing.T) {
 			repository := fsrepository.NewTemporary(dir)
 			repository.Overwrite("file.txt", []byte("some data"))
 
-			data, err := os.ReadFile(dir + "/file.txt")
+			data, err := os.ReadFile(filepath.Join(dir, "file.txt"))
 			assert.NoError(t, err)
 			assert.Equal(t, []byte("some data"), data)
 		})
 
 		t.Run("an existing regular file", func(t *testing.T) {
 			dir := t.TempDir()
-			assert.NoError(t, os.WriteFile(dir+"/file.txt", []byte("original data"), 0o600))
+			filePath := filepath.Join(dir, "file.txt")
+			assert.NoError(t, os.WriteFile(filePath, []byte("original data"), 0o600))
 
 			repository := fsrepository.NewTemporary(dir)
 			repository.Overwrite("file.txt", []byte("new data"))
 
-			data, err := os.ReadFile(dir + "/file.txt")
+			data, err := os.ReadFile(filePath)
 			assert.NoError(t, err)
 			assert.Equal(t, []byte("new data"), data)
-
-			stat, err := os.Stat(dir + "/file.txt")
-			assert.NoError(t, err)
-			mask := syscall.Umask(0)
-			defer syscall.Umask(mask)
-			assert.Equal(t, os.ModePerm^os.FileMode(mask), stat.Mode()) //nolint:gosec
 		})
 
-		t.Run("an existing linked file", func(t *testing.T) {
+		t.Run("an existing hard-linked file", func(t *testing.T) {
 			dir := t.TempDir()
-			assert.NoError(t, os.WriteFile(dir+"/file.txt", []byte("original data"), 0o600))
-			assert.NoError(t, os.Symlink(dir+"/file.txt", dir+"/linked.txt"))
+			sourcePath := filepath.Join(dir, "file.txt")
+			linkedPath := filepath.Join(dir, "linked.txt")
+			assert.NoError(t, os.WriteFile(sourcePath, []byte("original data"), 0o600))
+			assert.NoError(t, os.Link(sourcePath, linkedPath))
 
 			repository := fsrepository.NewTemporary(dir)
 			repository.Overwrite("linked.txt", []byte("new data"))
 
-			data, err := os.ReadFile(dir + "/linked.txt")
+			data, err := os.ReadFile(linkedPath)
 			assert.NoError(t, err)
 			assert.Equal(t, []byte("new data"), data)
+
+			source, err := os.ReadFile(sourcePath)
+			assert.NoError(t, err)
+			assert.Equal(t, []byte("original data"), source)
 		})
 
 		t.Run("does not allow writing past the given root path", func(t *testing.T) {
 			dir := t.TempDir()
-			assert.NoError(t, os.MkdirAll(dir+"/cant-overwrite/child", 0o700))
-			assert.NoError(t, os.WriteFile(dir+"/cant-overwrite/original.txt", []byte("original data"), 0o600))
+			assert.NoError(t, os.MkdirAll(filepath.Join(dir, "cant-overwrite", "child"), 0o700))
+			assert.NoError(t, os.WriteFile(filepath.Join(dir, "cant-overwrite", "original.txt"), []byte("original data"), 0o600))
 
-			repository := fsrepository.NewTemporary(dir + "/cant-overwrite/child")
+			repository := fsrepository.NewTemporary(filepath.Join(dir, "cant-overwrite", "child"))
 			assert.Panics(t, func() {
 				repository.Overwrite("../original.txt", []byte("new data"))
 			})
-			data, err := os.ReadFile(dir + "/cant-overwrite/original.txt")
+			data, err := os.ReadFile(filepath.Join(dir, "cant-overwrite", "original.txt"))
 			assert.NoError(t, err)
 			assert.Equal(t, []byte("original data"), data)
 		})
+
+		for _, rootPath := range []struct {
+			name string
+			path string
+		}{
+			{name: "an empty path does not overwrite the repository root", path: ""},
+			{name: "a dot path does not overwrite the repository root", path: "."},
+		} {
+			t.Run(rootPath.name, func(t *testing.T) {
+				dir := t.TempDir()
+				repository := fsrepository.NewTemporary(dir)
+
+				assert.Panics(t, func() {
+					repository.Overwrite(rootPath.path, []byte("new data"))
+				})
+
+				info, err := os.Stat(dir)
+				assert.NoError(t, err)
+				assert.True(t, info.IsDir())
+			})
+		}
 	})
 
 	t.Run("deleting", func(t *testing.T) {

--- a/internal/fsrepository/materialize_unix.go
+++ b/internal/fsrepository/materialize_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package fsrepository
+
+import (
+	"fmt"
+	"os"
+)
+
+func materializeFile(sourcePath, destinationPath string) error {
+	err := os.Symlink(sourcePath, destinationPath)
+	if err != nil {
+		return fmt.Errorf("create symbolic link: %w", err)
+	}
+
+	return nil
+}

--- a/internal/fsrepository/materialize_windows.go
+++ b/internal/fsrepository/materialize_windows.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package fsrepository
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func materializeFile(sourcePath, destinationPath string) error {
+	return materializeFileUsing(sourcePath, destinationPath, os.Link)
+}
+
+func materializeFileUsing(sourcePath, destinationPath string, createHardLink func(string, string) error) error {
+	err := createHardLink(sourcePath, destinationPath)
+	if err == nil {
+		return nil
+	}
+
+	return copyFile(sourcePath, destinationPath)
+}
+
+func copyFile(sourcePath, destinationPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer source.Close()
+
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	destination, err := os.OpenFile(destinationPath, flags, info.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("create destination: %w", err)
+	}
+
+	_, err = io.Copy(destination, source)
+	if err != nil {
+		_ = destination.Close()
+		_ = os.Remove(destinationPath)
+
+		return fmt.Errorf("copy source: %w", err)
+	}
+
+	err = destination.Close()
+	if err != nil {
+		_ = os.Remove(destinationPath)
+
+		return fmt.Errorf("close destination: %w", err)
+	}
+
+	return nil
+}

--- a/internal/fsrepository/materialize_windows_test.go
+++ b/internal/fsrepository/materialize_windows_test.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package fsrepository //nolint:testpackage // Exercises the private hard-link fallback seam.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaterializeFileCopiesWhenHardLinksAreUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.go")
+	destinationPath := filepath.Join(dir, "destination.go")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("package source\n"), 0o600))
+
+	linkAttempts := 0
+	createHardLink := func(actualSourcePath, actualDestinationPath string) error {
+		linkAttempts++
+		assert.Equal(t, sourcePath, actualSourcePath)
+		assert.Equal(t, destinationPath, actualDestinationPath)
+
+		return errors.New("hard links unavailable")
+	}
+
+	require.NoError(t, materializeFileUsing(sourcePath, destinationPath, createHardLink))
+	assert.Equal(t, 1, linkAttempts)
+
+	actual, err := os.ReadFile(destinationPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("package source\n"), actual)
+
+	require.NoError(t, os.WriteFile(destinationPath, []byte("package destination\n"), 0o600))
+	original, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("package source\n"), original)
+}

--- a/internal/fsrepository/overwrite_boundaries_unix_test.go
+++ b/internal/fsrepository/overwrite_boundaries_unix_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package fsrepository_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gtramontina/ooze/internal/fsrepository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverwriteDoesNotFollowParentSymlinksOutsideTheRepository(t *testing.T) {
+	externalDir := t.TempDir()
+	externalFile := filepath.Join(externalDir, "source.go")
+	require.NoError(t, os.WriteFile(externalFile, []byte("original"), 0o600))
+
+	repositoryDir := t.TempDir()
+	require.NoError(t, os.Symlink(externalDir, filepath.Join(repositoryDir, "escape")))
+	repository := fsrepository.NewTemporary(repositoryDir)
+
+	assert.Panics(t, func() {
+		repository.Overwrite("escape/source.go", []byte("mutated"))
+	})
+
+	content, err := os.ReadFile(externalFile)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("original"), content)
+}

--- a/internal/fsrepository/overwrite_permissions_unix_test.go
+++ b/internal/fsrepository/overwrite_permissions_unix_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package fsrepository_test
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/gtramontina/ooze/internal/fsrepository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverwriteHonorsTheProcessUmask(t *testing.T) {
+	dir := t.TempDir()
+	fsrepository.NewTemporary(dir).Overwrite("mutant.go", nil)
+
+	info, err := os.Stat(filepath.Join(dir, "mutant.go"))
+	require.NoError(t, err)
+
+	umask := syscall.Umask(0)
+	defer syscall.Umask(umask)
+	assert.Equal(t, os.ModePerm^os.FileMode(umask), info.Mode()) //nolint:gosec // Verifies umask behavior.
+}

--- a/internal/fsrepository/overwrite_permissions_windows_test.go
+++ b/internal/fsrepository/overwrite_permissions_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package fsrepository_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gtramontina/ooze/internal/fsrepository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverwriteLeavesMutantsWritable(t *testing.T) {
+	dir := t.TempDir()
+	fsrepository.NewTemporary(dir).Overwrite("mutant.go", nil)
+
+	info, err := os.Stat(filepath.Join(dir, "mutant.go"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode().Perm()&0o200)
+}

--- a/internal/ignoredrepository/ignoredrepository.go
+++ b/internal/ignoredrepository/ignoredrepository.go
@@ -35,6 +35,6 @@ FILE_LOOP:
 	return filtered
 }
 
-func (r *FilteredRepository) LinkAllToTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
-	return r.delegate.LinkAllToTemporaryRepository(temporaryPath)
+func (r *FilteredRepository) MaterializeTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
+	return r.delegate.MaterializeTemporaryRepository(temporaryPath)
 }

--- a/internal/ignoredrepository/ignoredrepository_test.go
+++ b/internal/ignoredrepository/ignoredrepository_test.go
@@ -97,7 +97,7 @@ func TestIgnoredRepository(t *testing.T) {
 	})
 }
 
-func TestIgnoredRepository_LinkAllToTemporaryRepository(t *testing.T) {
+func TestIgnoredRepository_MaterializeTemporaryRepository(t *testing.T) {
 	t.Run("delegates to underlying repository", func(t *testing.T) {
 		expectedTempRepository := fakerepository.NewTemporary()
 		repository := ignoredrepository.New(
@@ -105,7 +105,7 @@ func TestIgnoredRepository_LinkAllToTemporaryRepository(t *testing.T) {
 			fakerepository.New(fakerepository.FS{}, expectedTempRepository),
 		)
 
-		actualTempRepository := repository.LinkAllToTemporaryRepository("temporary-path")
+		actualTempRepository := repository.MaterializeTemporaryRepository("temporary-path")
 
 		assert.Equal(t, expectedTempRepository, actualTempRepository)
 		assert.Equal(t, "temporary-path", expectedTempRepository.Root())

--- a/internal/laboratory/laboratory.go
+++ b/internal/laboratory/laboratory.go
@@ -31,7 +31,7 @@ func (l *Laboratory) Test(
 	repository ooze.Repository,
 	file *gomutatedfile.GoMutatedFile,
 ) future.Future[result.Result[string]] {
-	tempRepository := repository.LinkAllToTemporaryRepository(l.temporaryDirectory.New())
+	tempRepository := repository.MaterializeTemporaryRepository(l.temporaryDirectory.New())
 	defer tempRepository.Remove()
 
 	file.WriteTo(tempRepository)

--- a/internal/ooze/ooze.go
+++ b/internal/ooze/ooze.go
@@ -15,7 +15,7 @@ type Logger interface {
 
 type Repository interface {
 	ListGoSourceFiles() []*gosourcefile.GoSourceFile
-	LinkAllToTemporaryRepository(temporaryPath string) TemporaryRepository
+	MaterializeTemporaryRepository(temporaryPath string) TemporaryRepository
 }
 
 type TemporaryRepository interface {

--- a/internal/oozetesting/fakerepository/fakerepository.go
+++ b/internal/oozetesting/fakerepository/fakerepository.go
@@ -51,7 +51,7 @@ func (r *FakeRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 	return sources
 }
 
-func (r *FakeRepository) LinkAllToTemporaryRepository(directoryPath string) ooze.TemporaryRepository {
+func (r *FakeRepository) MaterializeTemporaryRepository(directoryPath string) ooze.TemporaryRepository {
 	if r.tempCount >= len(r.temps) {
 		panic("fakerepository: temporary repositories not setup")
 	}

--- a/internal/verboserepository/verboserepository.go
+++ b/internal/verboserepository/verboserepository.go
@@ -25,10 +25,10 @@ func (r *VerboseRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 	return files
 }
 
-func (r *VerboseRepository) LinkAllToTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
-	r.logger.Logf("linking all files to temporary path '%s'…", temporaryPath)
-	repository := r.delegate.LinkAllToTemporaryRepository(temporaryPath)
-	r.logger.Logf("linked all files to temporary path '%s'", temporaryPath)
+func (r *VerboseRepository) MaterializeTemporaryRepository(temporaryPath string) ooze.TemporaryRepository {
+	r.logger.Logf("materializing all files at temporary path '%s'…", temporaryPath)
+	repository := r.delegate.MaterializeTemporaryRepository(temporaryPath)
+	r.logger.Logf("materialized all files at temporary path '%s'", temporaryPath)
 
 	return NewVerboseTemporaryRepository(r.logger, repository)
 }

--- a/internal/verboserepository/verboserepository_test.go
+++ b/internal/verboserepository/verboserepository_test.go
@@ -28,7 +28,7 @@ func TestVerboseRepository(t *testing.T) {
 		}, logger.LoggedLines())
 	})
 
-	t.Run("logs when linking to temporary path", func(t *testing.T) {
+	t.Run("logs when materializing at a temporary path", func(t *testing.T) {
 		logger := fakelogger.New()
 
 		verboserepository.New(
@@ -40,11 +40,11 @@ func TestVerboseRepository(t *testing.T) {
 				},
 				fakerepository.NewTemporaryAt("dummy"),
 			),
-		).LinkAllToTemporaryRepository("some-path")
+		).MaterializeTemporaryRepository("some-path")
 
 		assert.Equal(t, []string{
-			"linking all files to temporary path 'some-path'…",
-			"linked all files to temporary path 'some-path'",
+			"materializing all files at temporary path 'some-path'…",
+			"materialized all files at temporary path 'some-path'",
 		}, logger.LoggedLines())
 	})
 }
@@ -61,7 +61,7 @@ func TestTemporaryRepository(t *testing.T) {
 			),
 		)
 
-		temporary := repository.LinkAllToTemporaryRepository("some-path")
+		temporary := repository.MaterializeTemporaryRepository("some-path")
 		logger.Clear()
 
 		temporary.Overwrite("source.go", []byte("dummy"))
@@ -82,7 +82,7 @@ func TestTemporaryRepository(t *testing.T) {
 			),
 		)
 
-		temporary := repository.LinkAllToTemporaryRepository("some-path")
+		temporary := repository.MaterializeTemporaryRepository("some-path")
 		logger.Clear()
 
 		temporary.Remove()


### PR DESCRIPTION
Adds pinned Windows 2025 and macOS 15 compatibility coverage, then fixes the platform-specific filesystem behavior it exposes.

This supersedes the stale approach in #26 and addresses #19 and #20. The initial test-only commit intentionally leaves the Windows production failures visible before the fix.