### PR TITLE
fix: supervise test process trees

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/stretchr/testify v1.12.0
+	golang.org/x/sys v0.47.0
 )
 
 require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/cmdtestrunner/cmdtestrunner.go
+++ b/internal/cmdtestrunner/cmdtestrunner.go
@@ -1,6 +1,10 @@
 package cmdtestrunner
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 
@@ -25,10 +29,49 @@ func (t *CMDTestRunner) Test(repository ooze.TemporaryRepository) result.Result[
 	command.Dir = repository.Root()
 	command.Env = os.Environ()
 
-	output, err := command.CombinedOutput()
+	outputReader, outputWriter, err := os.Pipe()
 	if err != nil {
-		return result.Ok(string(output))
+		panic(fmt.Errorf("failed capturing test command output: %w", err))
 	}
 
-	return result.Err[string](string(output))
+	var output bytes.Buffer
+	outputCopied := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&output, outputReader)
+		outputCopied <- copyErr
+	}()
+	command.Stdout = outputWriter
+	command.Stderr = outputWriter
+
+	commandErr, supervisionErr := runProcessTree(command)
+	outputWriterCloseErr := outputWriter.Close()
+	if supervisionErr != nil {
+		_ = outputReader.Close()
+	}
+	outputCopyErr := <-outputCopied
+	outputReaderCloseErr := outputReader.Close()
+	if supervisionErr == nil {
+		supervisionErr = errors.Join(outputWriterCloseErr, outputCopyErr, outputReaderCloseErr)
+	}
+	if supervisionErr != nil {
+		panic(fmt.Errorf("failed supervising test command: %w", supervisionErr))
+	}
+	if commandErr != nil {
+		return result.Ok(output.String())
+	}
+
+	return result.Err[string](output.String())
+}
+
+func classifyCommandWait(waitErr error) (error, error) {
+	if waitErr == nil {
+		return nil, nil //nolint:nilnil // A successful wait belongs to neither error category.
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return fmt.Errorf("test command exited unsuccessfully: %w", waitErr), nil
+	}
+
+	return nil, fmt.Errorf("wait for test command: %w", waitErr)
 }

--- a/internal/cmdtestrunner/cmdtestrunner_test.go
+++ b/internal/cmdtestrunner/cmdtestrunner_test.go
@@ -1,9 +1,13 @@
 package cmdtestrunner_test
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/gtramontina/ooze/internal/cmdtestrunner"
 	"github.com/gtramontina/ooze/internal/oozetesting/fakerepository"
@@ -12,7 +16,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const helperProcessModeEnvironmentVariable = "OOZE_CMDTESTRUNNER_TEST_HELPER_MODE"
+const (
+	helperProcessModeEnvironmentVariable      = "OOZE_CMDTESTRUNNER_TEST_HELPER_MODE"
+	descendantClosesOutputEnvironmentVariable = "OOZE_CMDTESTRUNNER_TEST_DESCENDANT_CLOSES_OUTPUT"
+	helperProcessTimeout                      = 30 * time.Second
+	testProcessTimeout                        = 10 * time.Second
+)
+
+const (
+	descendantReadyFile    = "descendant-ready"
+	descendantObservedFile = "descendant-observed"
+	descendantReleaseFile  = "descendant-release"
+	descendantWriteFile    = "descendant-write"
+)
+
+type processExitObservation func()
 
 func TestMain(m *testing.M) {
 	switch os.Getenv(helperProcessModeEnvironmentVariable) {
@@ -33,6 +51,10 @@ func TestMain(m *testing.M) {
 	case "environment":
 		_, _ = os.Stdout.WriteString(os.Getenv("TEST_VAR"))
 		os.Exit(0)
+	case "spawn-descendant":
+		spawnDescendant()
+	case "delayed-write":
+		writeAfterParentExits()
 	default:
 		os.Exit(m.Run())
 	}
@@ -73,6 +95,140 @@ func TestCMDTestRunner(t *testing.T) {
 		output = newHelperCommand(t, "environment").Test(temporaryRepository)
 		assert.Equal(t, result.Err[string]("test_value_2"), output)
 	})
+
+	t.Run("panics when the test process cannot be started", func(t *testing.T) {
+		temporaryRepository := fakerepository.NewTemporaryAt(t.TempDir())
+		missingExecutable := filepath.Join(t.TempDir(), "missing-test-command")
+
+		assert.Panics(t, func() {
+			cmdtestrunner.New(missingExecutable).Test(temporaryRepository)
+		})
+	})
+
+	t.Run("does not return while a descendant holds its output handles", func(t *testing.T) {
+		assertDoesNotReturnWhileDescendantCanWrite(t, false)
+	})
+
+	t.Run("does not return while a descendant can write after closing its output handles", func(t *testing.T) {
+		assertDoesNotReturnWhileDescendantCanWrite(t, true)
+	})
+}
+
+func assertDoesNotReturnWhileDescendantCanWrite(t *testing.T, closesOutput bool) {
+	t.Helper()
+	if !descendantSupervisionSupported {
+		t.Skip("process-tree supervision is unavailable on this operating system")
+	}
+	t.Setenv(descendantClosesOutputEnvironmentVariable, strconv.FormatBool(closesOutput))
+	dir := t.TempDir()
+	temporaryRepository := fakerepository.NewTemporaryAt(dir)
+	runner := newHelperCommand(t, "spawn-descendant")
+
+	outputChannel := make(chan result.Result[string], 1)
+	go func() {
+		outputChannel <- runner.Test(temporaryRepository)
+	}()
+	t.Cleanup(func() {
+		_ = os.WriteFile(filepath.Join(dir, descendantObservedFile), nil, 0o600)
+		_ = os.WriteFile(filepath.Join(dir, descendantReleaseFile), nil, 0o600)
+	})
+
+	var descendantProcessID int
+	require.Eventually(t, func() bool {
+		readyFileContents, err := os.ReadFile(filepath.Join(dir, descendantReadyFile))
+		if err != nil {
+			return false
+		}
+
+		descendantProcessID, err = strconv.Atoi(string(readyFileContents))
+
+		return err == nil
+	}, testProcessTimeout, 10*time.Millisecond)
+	assertDescendantExited, err := observeProcessExit(t, descendantProcessID)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, descendantObservedFile), nil, 0o600))
+
+	var output result.Result[string]
+	select {
+	case output = <-outputChannel:
+	case <-time.After(testProcessTimeout):
+		require.NoError(t, os.WriteFile(filepath.Join(dir, descendantReleaseFile), nil, 0o600))
+		select {
+		case <-outputChannel:
+		case <-time.After(testProcessTimeout):
+		}
+		require.FailNow(t, "Test remained blocked while supervising a descendant")
+	}
+	assert.Equal(t, result.Err[string](""), output)
+	assertDescendantExited()
+	assert.NoFileExists(t, filepath.Join(dir, descendantWriteFile))
+}
+
+func spawnDescendant() {
+	executable, err := os.Executable()
+	if err != nil {
+		os.Exit(2)
+	}
+
+	err = os.Setenv(helperProcessModeEnvironmentVariable, "delayed-write")
+	if err != nil {
+		os.Exit(2)
+	}
+
+	command := exec.Command(executable) //nolint:noctx // Test helper has its own bounded lifecycle.
+	command.Env = os.Environ()
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	err = command.Start()
+	if err != nil {
+		os.Exit(2)
+	}
+
+	if !waitForFile(descendantReadyFile) {
+		os.Exit(2)
+	}
+	if !waitForFile(descendantObservedFile) {
+		os.Exit(2)
+	}
+
+	os.Exit(0)
+}
+
+func writeAfterParentExits() {
+	err := os.WriteFile(descendantReadyFile, []byte(strconv.Itoa(os.Getpid())), 0o600)
+	if err != nil {
+		os.Exit(2)
+	}
+	if os.Getenv(descendantClosesOutputEnvironmentVariable) == "true" {
+		if errors.Join(os.Stdout.Close(), os.Stderr.Close()) != nil {
+			os.Exit(2)
+		}
+	}
+
+	if !waitForFile(descendantReleaseFile) {
+		os.Exit(2)
+	}
+
+	err = os.WriteFile(descendantWriteFile, []byte("written by descendant"), 0o600)
+	if err != nil {
+		os.Exit(2)
+	}
+
+	os.Exit(0)
+}
+
+func waitForFile(path string) bool {
+	deadline := time.Now().Add(helperProcessTimeout)
+	for {
+		_, err := os.Stat(path)
+		if err == nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func newHelperCommand(t *testing.T, mode string) *cmdtestrunner.CMDTestRunner {

--- a/internal/cmdtestrunner/process_guardian_unix.go
+++ b/internal/cmdtestrunner/process_guardian_unix.go
@@ -1,0 +1,44 @@
+//go:build darwin || linux
+
+package cmdtestrunner
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+)
+
+const processGuardianConfigurationFD = 3
+
+var errProcessGuardianCommandArgumentsMissing = errors.New("process guardian command arguments are missing")
+
+type processGuardianCommand struct {
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+	Dir  string   `json:"dir"`
+	Env  []string `json:"env"`
+}
+
+func decodeProcessGuardianCommand(file *os.File, command *processGuardianCommand) error {
+	decodeErr := json.NewDecoder(file).Decode(command)
+	closeErr := file.Close()
+	var validationErr error
+	if decodeErr == nil && len(command.Args) == 0 {
+		validationErr = errProcessGuardianCommandArgumentsMissing
+	}
+
+	return errors.Join(decodeErr, closeErr, validationErr)
+}
+
+func environmentWithout(environment []string, name string) []string {
+	prefix := name + "="
+	filtered := make([]string, 0, len(environment))
+	for _, variable := range environment {
+		if !strings.HasPrefix(variable, prefix) {
+			filtered = append(filtered, variable)
+		}
+	}
+
+	return filtered
+}

--- a/internal/cmdtestrunner/process_guardian_unix_internal_test.go
+++ b/internal/cmdtestrunner/process_guardian_unix_internal_test.go
@@ -1,0 +1,30 @@
+//go:build darwin || linux
+
+package cmdtestrunner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeProcessGuardianCommandRejectsMissingArguments(t *testing.T) {
+	configurationReader, configurationWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	configuration := processGuardianCommand{
+		Path: "test-command",
+		Args: nil,
+		Dir:  "",
+		Env:  nil,
+	}
+	require.NoError(t, json.NewEncoder(configurationWriter).Encode(configuration))
+	require.NoError(t, configurationWriter.Close())
+
+	var command processGuardianCommand
+	err = decodeProcessGuardianCommand(configurationReader, &command)
+
+	require.ErrorIs(t, err, errProcessGuardianCommandArgumentsMissing)
+}

--- a/internal/cmdtestrunner/process_test_darwin_test.go
+++ b/internal/cmdtestrunner/process_test_darwin_test.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package cmdtestrunner_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+const descendantSupervisionSupported = true
+
+func observeProcessExit(t *testing.T, processID int) (processExitObservation, error) {
+	t.Helper()
+
+	queue, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create process exit observation queue: %w", err)
+	}
+	t.Cleanup(func() { require.NoError(t, unix.Close(queue)) })
+
+	changes := []unix.Kevent_t{{
+		Ident:  uint64(processID), //nolint:gosec // Darwin process IDs are non-negative integers.
+		Filter: unix.EVFILT_PROC,
+		Flags:  unix.EV_ADD | unix.EV_ONESHOT,
+		Fflags: unix.NOTE_EXIT,
+		Data:   0,
+		Udata:  nil,
+	}}
+	_, err = unix.Kevent(queue, changes, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("observe process %d exit: %w", processID, err)
+	}
+
+	return func() {
+		events := make([]unix.Kevent_t, 1)
+		observed, observeErr := unix.Kevent(queue, nil, events, &unix.Timespec{Sec: 0, Nsec: 0})
+		require.NoError(t, observeErr)
+		require.Equal(t, 1, observed)
+		require.NotZero(t, events[0].Fflags&uint32(unix.NOTE_EXIT))
+	}, nil
+}

--- a/internal/cmdtestrunner/process_test_linux_test.go
+++ b/internal/cmdtestrunner/process_test_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package cmdtestrunner_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+const descendantSupervisionSupported = true
+
+func observeProcessExit(t *testing.T, processID int) (processExitObservation, error) {
+	t.Helper()
+
+	processDescriptor, err := unix.PidfdOpen(processID, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open process %d to observe its exit: %w", processID, err)
+	}
+	t.Cleanup(func() { require.NoError(t, unix.Close(processDescriptor)) })
+
+	return func() {
+		pollDescriptors := []unix.PollFd{{
+			Fd:      int32(processDescriptor), //nolint:gosec // File descriptors fit int32 on Linux.
+			Events:  unix.POLLIN,
+			Revents: 0,
+		}}
+		observed, pollErr := unix.Poll(pollDescriptors, 0)
+		require.NoError(t, pollErr)
+		require.Equal(t, 1, observed)
+		require.NotZero(t, pollDescriptors[0].Revents&unix.POLLIN)
+	}, nil
+}

--- a/internal/cmdtestrunner/process_test_other_unix_test.go
+++ b/internal/cmdtestrunner/process_test_other_unix_test.go
@@ -1,0 +1,11 @@
+//go:build !windows && !darwin && !linux
+
+package cmdtestrunner_test
+
+import "testing"
+
+const descendantSupervisionSupported = false
+
+func observeProcessExit(*testing.T, int) (processExitObservation, error) {
+	return func() {}, nil
+}

--- a/internal/cmdtestrunner/process_test_windows_test.go
+++ b/internal/cmdtestrunner/process_test_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package cmdtestrunner_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+const descendantSupervisionSupported = true
+
+func observeProcessExit(t *testing.T, processID int) (processExitObservation, error) {
+	t.Helper()
+
+	process, err := windows.OpenProcess(
+		windows.SYNCHRONIZE,
+		false,
+		uint32(processID), //nolint:gosec // Windows process IDs are 32-bit values.
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open process %d to observe its exit: %w", processID, err)
+	}
+	t.Cleanup(func() { require.NoError(t, windows.CloseHandle(process)) })
+
+	return func() {
+		status, waitErr := windows.WaitForSingleObject(process, 0)
+		require.NoError(t, waitErr)
+		require.Equal(t, uint32(windows.WAIT_OBJECT_0), status)
+	}, nil
+}

--- a/internal/cmdtestrunner/process_tree_darwin.go
+++ b/internal/cmdtestrunner/process_tree_darwin.go
@@ -1,0 +1,369 @@
+//go:build darwin
+
+package cmdtestrunner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinLauncherModeEnvironmentVariable = "OOZE_INTERNAL_DARWIN_PROCESS_LAUNCHER"
+	darwinLauncherMode                    = "v1"
+	darwinLauncherStatusFD                = 4
+	darwinLauncherInfrastructureExitCode  = 125
+	darwinProcessTerminationTimeout       = 5 * time.Second
+	darwinZombieProcessState              = 5
+)
+
+var (
+	errDarwinProcessTerminationTimeout = errors.New("darwin process termination timed out")
+	errDarwinCommandLaunchFailed       = errors.New("darwin command launch failed")
+	errDarwinLauncherExited            = errors.New("darwin process launcher exited before suspension")
+	errDarwinUnexpectedProcessEvent    = errors.New("unexpected darwin process event")
+	errDarwinUnexpectedWaitStatus      = errors.New("unexpected darwin wait status")
+)
+
+type darwinLauncherWaitState uint8
+
+const (
+	darwinLauncherWaitStateUnknown darwinLauncherWaitState = iota
+	darwinLauncherWaitStateStopped
+	darwinLauncherWaitStateExited
+)
+
+type darwinProcessTracker struct {
+	queue        int
+	processGroup int
+}
+
+type darwinLauncherPipes struct {
+	configurationReader *os.File
+	configurationWriter *os.File
+	statusReader        *os.File
+	statusWriter        *os.File
+}
+
+func (p darwinLauncherPipes) close() {
+	_ = p.configurationReader.Close()
+	_ = p.configurationWriter.Close()
+	_ = p.statusReader.Close()
+	_ = p.statusWriter.Close()
+}
+
+//nolint:gochecknoinits // Re-execution must enter launcher mode before the host program's main function.
+func init() {
+	if os.Getenv(darwinLauncherModeEnvironmentVariable) != darwinLauncherMode {
+		return
+	}
+
+	os.Exit(runDarwinLauncher())
+}
+
+func runProcessTree(command *exec.Cmd) (error, error) {
+	launcher, pipes, err := newDarwinLauncher(command)
+	if err != nil {
+		return nil, err
+	}
+
+	err = launcher.Start()
+	if err != nil {
+		pipes.close()
+
+		return nil, fmt.Errorf("start Darwin process launcher: %w", err)
+	}
+	_ = pipes.configurationReader.Close()
+	_ = pipes.statusWriter.Close()
+
+	configuration := processGuardianCommand{
+		Path: command.Path,
+		Args: command.Args,
+		Dir:  command.Dir,
+		Env:  environmentWithout(command.Env, darwinLauncherModeEnvironmentVariable),
+	}
+	configurationErr := writeDarwinLauncherConfiguration(pipes.configurationWriter, configuration)
+	if configurationErr != nil {
+		return nil, errors.Join(configurationErr, pipes.statusReader.Close(), stopAndWaitDarwinLauncher(launcher))
+	}
+
+	launcherState, err := waitForDarwinLauncherStop(launcher.Process.Pid)
+	if launcherState == darwinLauncherWaitStateExited {
+		return nil, finishExitedDarwinLauncher(launcher, pipes.statusReader, err)
+	}
+	if err != nil {
+		_ = pipes.statusReader.Close()
+
+		return nil, errors.Join(err, stopAndWaitDarwinLauncher(launcher))
+	}
+
+	tracker, err := newDarwinProcessTracker(launcher.Process.Pid)
+	if err != nil {
+		_ = pipes.statusReader.Close()
+
+		return nil, errors.Join(err, stopAndWaitDarwinLauncher(launcher))
+	}
+	defer func() { _ = unix.Close(tracker.queue) }()
+
+	err = syscall.Kill(launcher.Process.Pid, syscall.SIGCONT)
+	if err != nil {
+		_ = pipes.statusReader.Close()
+
+		return nil, errors.Join(fmt.Errorf("release Darwin process launcher: %w", err), stopAndWaitDarwinLauncher(launcher))
+	}
+
+	statusErr := readDarwinLauncherStatus(pipes.statusReader)
+	rootExitErr := tracker.waitForRootExit()
+	terminationErr := tracker.terminateAndWait()
+	commandErr, waitErr := classifyCommandWait(launcher.Wait())
+
+	return commandErr, errors.Join(statusErr, rootExitErr, terminationErr, waitErr)
+}
+
+func finishExitedDarwinLauncher(launcher *exec.Cmd, statusReader *os.File, waitErr error) error {
+	statusErr := readDarwinLauncherStatus(statusReader)
+	releaseErr := launcher.Process.Release()
+
+	return errors.Join(waitErr, statusErr, releaseErr)
+}
+
+func readDarwinLauncherStatus(reader *os.File) error {
+	launcherStatus, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if len(launcherStatus) == 0 {
+		return errors.Join(readErr, closeErr)
+	}
+
+	return errors.Join(
+		readErr,
+		closeErr,
+		fmt.Errorf("%w: %s", errDarwinCommandLaunchFailed, strings.TrimSpace(string(launcherStatus))),
+	)
+}
+
+func newDarwinLauncher(command *exec.Cmd) (*exec.Cmd, darwinLauncherPipes, error) {
+	configurationReader, configurationWriter, err := os.Pipe()
+	if err != nil {
+		return nil, darwinLauncherPipes{}, fmt.Errorf("create Darwin launcher configuration pipe: %w", err)
+	}
+	statusReader, statusWriter, err := os.Pipe()
+	if err != nil {
+		_ = configurationReader.Close()
+		_ = configurationWriter.Close()
+
+		return nil, darwinLauncherPipes{}, fmt.Errorf("create Darwin launcher status pipe: %w", err)
+	}
+	pipes := darwinLauncherPipes{
+		configurationReader: configurationReader,
+		configurationWriter: configurationWriter,
+		statusReader:        statusReader,
+		statusWriter:        statusWriter,
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		pipes.close()
+
+		return nil, darwinLauncherPipes{}, fmt.Errorf("locate Darwin process launcher: %w", err)
+	}
+
+	launcher := exec.Command(executable) //nolint:noctx // Re-executes this trusted binary in private launcher mode.
+	launcher.Env = append(
+		environmentWithout(command.Env, darwinLauncherModeEnvironmentVariable),
+		darwinLauncherModeEnvironmentVariable+"="+darwinLauncherMode,
+	)
+	launcher.ExtraFiles = []*os.File{configurationReader, statusWriter}
+	launcher.Stdout = command.Stdout
+	launcher.Stderr = command.Stderr
+	//nolint:exhaustruct // Other process attributes retain OS defaults.
+	launcher.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	return launcher, pipes, nil
+}
+
+func writeDarwinLauncherConfiguration(writer *os.File, configuration processGuardianCommand) error {
+	encodeErr := json.NewEncoder(writer).Encode(configuration)
+	closeErr := writer.Close()
+
+	return errors.Join(encodeErr, closeErr)
+}
+
+func runDarwinLauncher() int {
+	configurationFile := os.NewFile(processGuardianConfigurationFD, "darwin-launcher-configuration")
+	statusFile := os.NewFile(darwinLauncherStatusFD, "darwin-launcher-status")
+	if configurationFile == nil || statusFile == nil {
+		return darwinLauncherInfrastructureExitCode
+	}
+	defer func() { _ = statusFile.Close() }()
+
+	var configuration processGuardianCommand
+	err := decodeProcessGuardianCommand(configurationFile, &configuration)
+	if err != nil {
+		_, _ = fmt.Fprintf(statusFile, "decode launcher configuration: %v", err)
+
+		return darwinLauncherInfrastructureExitCode
+	}
+	unix.CloseOnExec(darwinLauncherStatusFD)
+
+	err = syscall.Kill(os.Getpid(), syscall.SIGSTOP)
+	if err != nil {
+		_, _ = fmt.Fprintf(statusFile, "stop launcher before execution: %v", err)
+
+		return darwinLauncherInfrastructureExitCode
+	}
+
+	err = syscall.Chdir(configuration.Dir)
+	if err == nil {
+		//nolint:gosec // The caller supplied this trusted test command.
+		err = syscall.Exec(configuration.Path, configuration.Args, configuration.Env)
+	}
+	_, _ = fmt.Fprintf(statusFile, "%v", err)
+
+	return darwinLauncherInfrastructureExitCode
+}
+
+func waitForDarwinLauncherStop(processID int) (darwinLauncherWaitState, error) {
+	var status syscall.WaitStatus
+	for {
+		observedProcessID, err := syscall.Wait4(processID, &status, syscall.WUNTRACED, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return darwinLauncherWaitStateUnknown, fmt.Errorf("await Darwin launcher suspension: %w", err)
+		}
+		if observedProcessID != processID {
+			return darwinLauncherWaitStateUnknown, fmt.Errorf(
+				"await Darwin launcher suspension: %w %d",
+				errDarwinUnexpectedWaitStatus,
+				status,
+			)
+		}
+		if status.Exited() || status.Signaled() {
+			return darwinLauncherWaitStateExited, fmt.Errorf("%w: %d", errDarwinLauncherExited, status)
+		}
+		if !darwinWaitStatusIsSIGSTOP(status) {
+			return darwinLauncherWaitStateUnknown, fmt.Errorf(
+				"await Darwin launcher suspension: %w %d",
+				errDarwinUnexpectedWaitStatus,
+				status,
+			)
+		}
+
+		return darwinLauncherWaitStateStopped, nil
+	}
+}
+
+func newDarwinProcessTracker(processID int) (*darwinProcessTracker, error) {
+	queue, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create Darwin process tracking queue: %w", err)
+	}
+
+	change := unix.Kevent_t{
+		Ident:  uint64(processID), //nolint:gosec // Darwin process IDs are non-negative integers.
+		Filter: unix.EVFILT_PROC,
+		Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_ONESHOT,
+		Fflags: unix.NOTE_EXIT,
+		Data:   0,
+		Udata:  nil,
+	}
+	_, err = unix.Kevent(queue, []unix.Kevent_t{change}, nil, nil)
+	if err != nil {
+		_ = unix.Close(queue)
+
+		return nil, fmt.Errorf("track Darwin process tree: %w", err)
+	}
+
+	return &darwinProcessTracker{
+		queue:        queue,
+		processGroup: processID,
+	}, nil
+}
+
+func (t *darwinProcessTracker) waitForRootExit() error {
+	events := make([]unix.Kevent_t, 1)
+	var observed int
+	var err error
+	for {
+		observed, err = unix.Kevent(t.queue, nil, events, nil)
+		if !errors.Is(err, syscall.EINTR) {
+			break
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("await Darwin command exit: %w", err)
+	}
+	if observed != 1 || events[0].Flags&unix.EV_ERROR != 0 || events[0].Fflags&unix.NOTE_EXIT == 0 {
+		return fmt.Errorf("await Darwin command exit: %w", errDarwinUnexpectedProcessEvent)
+	}
+
+	return nil
+}
+
+func (t *darwinProcessTracker) terminateAndWait() error {
+	deadline := time.Now().Add(darwinProcessTerminationTimeout)
+	for {
+		hasExecutableProcesses, err := darwinProcessGroupHasExecutableProcesses(t.processGroup)
+		if err != nil {
+			return err
+		}
+		if !hasExecutableProcesses {
+			return nil
+		}
+
+		err = syscall.Kill(-t.processGroup, syscall.SIGKILL)
+		if err != nil && !errors.Is(err, syscall.EPERM) && !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("terminate Darwin process tree %d: %w", t.processGroup, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w after %s", errDarwinProcessTerminationTimeout, darwinProcessTerminationTimeout)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func darwinProcessGroupHasExecutableProcesses(processGroup int) (bool, error) {
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.pgrp", processGroup)
+	if err != nil {
+		return false, fmt.Errorf("inspect Darwin process group %d: %w", processGroup, err)
+	}
+
+	for _, process := range processes {
+		if int(process.Proc.P_pid) == processGroup {
+			continue
+		}
+		if process.Proc.P_stat != darwinZombieProcessState {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func stopAndWaitDarwinLauncher(command *exec.Cmd) error {
+	killErr := command.Process.Kill()
+	_, waitErr := classifyCommandWait(command.Wait())
+
+	return errors.Join(killErr, waitErr)
+}
+
+func darwinWaitStatusIsSIGSTOP(status syscall.WaitStatus) bool {
+	const (
+		waitStatusMask    = 0x7f
+		waitStatusStopped = 0x7f
+		waitStatusShift   = 8
+	)
+
+	value := uint32(status)
+
+	return value&waitStatusMask == waitStatusStopped && syscall.Signal(value>>waitStatusShift) == syscall.SIGSTOP
+}

--- a/internal/cmdtestrunner/process_tree_darwin_internal_test.go
+++ b/internal/cmdtestrunner/process_tree_darwin_internal_test.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package cmdtestrunner
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForDarwinLauncherStopRecognizesAnExitedLauncher(t *testing.T) {
+	launcher := exec.Command("/usr/bin/true") //nolint:noctx // The command exits immediately and is reaped by the test.
+	require.NoError(t, launcher.Start())
+
+	state, err := waitForDarwinLauncherStop(launcher.Process.Pid)
+
+	assert.Equal(t, darwinLauncherWaitStateExited, state)
+	assert.ErrorIs(t, err, errDarwinLauncherExited)
+	statusReader, statusWriter, pipeErr := os.Pipe()
+	require.NoError(t, pipeErr)
+	require.NoError(t, statusWriter.Close())
+
+	finishErr := finishExitedDarwinLauncher(launcher, statusReader, err)
+
+	assert.ErrorIs(t, finishErr, errDarwinLauncherExited)
+	assert.Equal(t, -1, launcher.Process.Pid)
+	assert.Error(t, launcher.Process.Kill())
+}

--- a/internal/cmdtestrunner/process_tree_linux.go
+++ b/internal/cmdtestrunner/process_tree_linux.go
@@ -1,0 +1,332 @@
+//go:build linux
+
+package cmdtestrunner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	linuxGuardianModeEnvironmentVariable = "OOZE_INTERNAL_LINUX_PROCESS_GUARDIAN"
+	linuxGuardianMode                    = "v1"
+	linuxGuardianCommandFailedExitCode   = 1
+	linuxGuardianInfrastructureExitCode  = 125
+	linuxGuardianTerminationTimeout      = 5 * time.Second
+)
+
+var (
+	errLinuxGuardianTerminationTimeout = errors.New("linux guardian termination timed out")
+	errLinuxParentProcessIDMissing     = errors.New("linux parent process ID is missing")
+)
+
+//nolint:gochecknoinits // Re-execution must enter guardian mode before the host program's main function.
+func init() {
+	if os.Getenv(linuxGuardianModeEnvironmentVariable) != linuxGuardianMode {
+		return
+	}
+
+	os.Exit(runLinuxGuardian())
+}
+
+func runProcessTree(command *exec.Cmd) (error, error) {
+	configurationReader, configurationWriter, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create Linux guardian configuration pipe: %w", err)
+	}
+	defer func() { _ = configurationReader.Close() }()
+
+	executable, err := os.Executable()
+	if err != nil {
+		_ = configurationWriter.Close()
+
+		return nil, fmt.Errorf("locate Linux process guardian: %w", err)
+	}
+
+	guardian := exec.Command(executable) //nolint:noctx // Re-executes this trusted binary in private guardian mode.
+	guardian.Env = environmentWithout(command.Env, linuxGuardianModeEnvironmentVariable)
+	guardian.Env = append(guardian.Env, linuxGuardianModeEnvironmentVariable+"="+linuxGuardianMode)
+	guardian.ExtraFiles = []*os.File{configurationReader}
+	guardian.Stdout = command.Stdout
+	guardian.Stderr = command.Stderr
+
+	err = guardian.Start()
+	if err != nil {
+		_ = configurationWriter.Close()
+
+		return nil, fmt.Errorf("start Linux process guardian: %w", err)
+	}
+	_ = configurationReader.Close()
+
+	configuration := processGuardianCommand{
+		Path: command.Path,
+		Args: command.Args,
+		Dir:  command.Dir,
+		Env:  environmentWithout(command.Env, linuxGuardianModeEnvironmentVariable),
+	}
+	encodeErr := json.NewEncoder(configurationWriter).Encode(configuration)
+	closeErr := configurationWriter.Close()
+	if encodeErr != nil || closeErr != nil {
+		killErr := guardian.Process.Kill()
+		_, waitErr := classifyCommandWait(guardian.Wait())
+
+		return nil, errors.Join(
+			fmt.Errorf("configure Linux process guardian: %w", errors.Join(encodeErr, closeErr)),
+			killErr,
+			waitErr,
+		)
+	}
+
+	return classifyLinuxGuardianWait(guardian.Wait())
+}
+
+func runLinuxGuardian() int {
+	configurationFile := os.NewFile(processGuardianConfigurationFD, "linux-guardian-configuration")
+	if configurationFile == nil {
+		return linuxGuardianInfrastructureExitCode
+	}
+
+	var configuration processGuardianCommand
+	err := decodeProcessGuardianCommand(configurationFile, &configuration)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "decode Linux guardian configuration: %v\n", err)
+
+		return linuxGuardianInfrastructureExitCode
+	}
+
+	err = unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "configure Linux child subreaper: %v\n", err)
+
+		return linuxGuardianInfrastructureExitCode
+	}
+
+	//nolint:gosec,noctx // The caller supplied this trusted test command; the guardian has no cancellation context.
+	command := exec.Command(configuration.Path, configuration.Args[1:]...)
+	command.Dir = configuration.Dir
+	command.Env = configuration.Env
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	//nolint:exhaustruct // Other process attributes retain OS defaults.
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	err = command.Start()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "start supervised command: %v\n", err)
+
+		return linuxGuardianInfrastructureExitCode
+	}
+
+	commandFailed, waitErr := guardianCommandFailed(command.Wait())
+	terminationErr := terminateLinuxGuardianDescendants()
+	if waitErr != nil || terminationErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "supervise command: %v\n", errors.Join(waitErr, terminationErr))
+
+		return linuxGuardianInfrastructureExitCode
+	}
+	if commandFailed {
+		return linuxGuardianCommandFailedExitCode
+	}
+
+	return 0
+}
+
+func guardianCommandFailed(waitErr error) (bool, error) {
+	if waitErr == nil {
+		return false, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("wait for supervised command: %w", waitErr)
+}
+
+func terminateLinuxGuardianDescendants() error {
+	deadline := time.Now().Add(linuxGuardianTerminationTimeout)
+	for {
+		hasChildren, err := reapExitedGuardianChildren()
+		if err != nil {
+			return err
+		}
+		if !hasChildren {
+			return nil
+		}
+
+		childProcessIDs, err := linuxGuardianChildProcessIDs()
+		if err != nil {
+			return err
+		}
+		for _, processID := range childProcessIDs {
+			err = syscall.Kill(processID, syscall.SIGKILL)
+			if err != nil && !errors.Is(err, syscall.ESRCH) {
+				return fmt.Errorf("terminate adopted process %d: %w", processID, err)
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"terminate adopted processes: %w after %s",
+				errLinuxGuardianTerminationTimeout,
+				linuxGuardianTerminationTimeout,
+			)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func reapExitedGuardianChildren() (bool, error) {
+	for {
+		var status syscall.WaitStatus
+		processID, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if errors.Is(err, syscall.ECHILD) {
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("reap adopted process: %w", err)
+		}
+		if processID == 0 {
+			return true, nil
+		}
+	}
+}
+
+func linuxGuardianChildProcessIDs() ([]int, error) {
+	return linuxGuardianChildProcessIDsAt("/proc/self/task", "/proc", os.Getpid())
+}
+
+func linuxGuardianChildProcessIDsAt(taskRoot, processRoot string, guardianProcessID int) ([]int, error) {
+	processIDs, childrenFilesAvailable, err := linuxGuardianTaskChildProcessIDs(taskRoot)
+	if err != nil {
+		return nil, err
+	}
+	if childrenFilesAvailable {
+		return processIDs, nil
+	}
+
+	return linuxGuardianDirectChildProcessIDs(processRoot, guardianProcessID)
+}
+
+func linuxGuardianTaskChildProcessIDs(taskRoot string) ([]int, bool, error) {
+	taskDirectories, err := os.ReadDir(taskRoot)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect Linux guardian tasks: %w", err)
+	}
+
+	childrenFilesAvailable := false
+	processIDs := make(map[int]struct{})
+	for _, taskDirectory := range taskDirectories {
+		childrenPath := filepath.Join(taskRoot, taskDirectory.Name(), "children")
+		contents, readErr := os.ReadFile(childrenPath)
+		if errors.Is(readErr, os.ErrNotExist) {
+			continue
+		}
+		if readErr != nil {
+			return nil, false, fmt.Errorf("inspect Linux guardian children: %w", readErr)
+		}
+		childrenFilesAvailable = true
+
+		for value := range strings.FieldsSeq(string(contents)) {
+			processID, conversionErr := strconv.Atoi(value)
+			if conversionErr != nil {
+				return nil, false, fmt.Errorf("parse Linux guardian child process ID %q: %w", value, conversionErr)
+			}
+			processIDs[processID] = struct{}{}
+		}
+	}
+
+	result := make([]int, 0, len(processIDs))
+	for processID := range processIDs {
+		result = append(result, processID)
+	}
+
+	return result, childrenFilesAvailable, nil
+}
+
+func linuxGuardianDirectChildProcessIDs(processRoot string, guardianProcessID int) ([]int, error) {
+	processDirectories, err := os.ReadDir(processRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect Linux processes: %w", err)
+	}
+
+	processIDs := make([]int, 0)
+	for _, processDirectory := range processDirectories {
+		processID, conversionErr := strconv.Atoi(processDirectory.Name())
+		if conversionErr != nil {
+			continue
+		}
+
+		statusPath := filepath.Join(processRoot, processDirectory.Name(), "status")
+		contents, readErr := os.ReadFile(statusPath)
+		if linuxProcessStatusIsUninspectable(readErr) {
+			continue
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("inspect Linux process %d: %w", processID, readErr)
+		}
+
+		parentProcessID, parseErr := linuxParentProcessID(contents)
+		if errors.Is(parseErr, errLinuxParentProcessIDMissing) {
+			continue
+		}
+		if parseErr != nil {
+			return nil, fmt.Errorf("inspect Linux process %d: %w", processID, parseErr)
+		}
+		if parentProcessID == guardianProcessID {
+			processIDs = append(processIDs, processID)
+		}
+	}
+
+	return processIDs, nil
+}
+
+func linuxProcessStatusIsUninspectable(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.ESRCH)
+}
+
+func linuxParentProcessID(status []byte) (int, error) {
+	const parentProcessIDLabel = "PPid:"
+
+	for line := range strings.Lines(string(status)) {
+		value, found := strings.CutPrefix(line, parentProcessIDLabel)
+		if !found {
+			continue
+		}
+
+		parentProcessID, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return 0, fmt.Errorf("parse parent process ID %q: %w", strings.TrimSpace(value), err)
+		}
+
+		return parentProcessID, nil
+	}
+
+	return 0, errLinuxParentProcessIDMissing
+}
+
+func classifyLinuxGuardianWait(waitErr error) (error, error) {
+	if waitErr == nil {
+		return nil, nil //nolint:nilnil // A successful command belongs to neither error category.
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) && exitErr.ExitCode() == linuxGuardianCommandFailedExitCode {
+		return fmt.Errorf("test command exited unsuccessfully: %w", waitErr), nil
+	}
+
+	return nil, fmt.Errorf("linux process guardian failed: %w", waitErr)
+}

--- a/internal/cmdtestrunner/process_tree_linux_internal_test.go
+++ b/internal/cmdtestrunner/process_tree_linux_internal_test.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package cmdtestrunner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinuxGuardianChildProcessIDsFallsBackToProcessStatus(t *testing.T) {
+	processRoot := t.TempDir()
+	taskRoot := filepath.Join(processRoot, "self", "task")
+	require.NoError(t, os.MkdirAll(filepath.Join(taskRoot, "1"), 0o700))
+	writeLinuxProcessStatus(t, processRoot, "101", "guardian-child", 42)
+	writeLinuxProcessStatus(t, processRoot, "202", "unrelated", 7)
+	require.NoError(t, os.MkdirAll(filepath.Join(processRoot, "303"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(processRoot, "404"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(processRoot, "404", "status"), []byte("Name:\tmissing-parent\n"), 0o600))
+
+	processIDs, err := linuxGuardianChildProcessIDsAt(taskRoot, processRoot, 42)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int{101}, processIDs)
+}
+
+func TestLinuxProcessStatusIsUninspectable(t *testing.T) {
+	for _, statusErr := range []error{
+		os.ErrNotExist,
+		os.ErrPermission,
+		syscall.ESRCH,
+		fmt.Errorf("inspect status: %w", syscall.EPERM),
+	} {
+		assert.True(t, linuxProcessStatusIsUninspectable(statusErr))
+	}
+
+	assert.False(t, linuxProcessStatusIsUninspectable(syscall.EIO))
+}
+
+func TestLinuxGuardianChildProcessIDsPrefersTheKernelChildrenInterface(t *testing.T) {
+	processRoot := t.TempDir()
+	taskRoot := filepath.Join(processRoot, "self", "task")
+	require.NoError(t, os.MkdirAll(filepath.Join(taskRoot, "1"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(taskRoot, "1", "children"), []byte("303 "), 0o600))
+	writeLinuxProcessStatus(t, processRoot, "101", "status-only-child", 42)
+
+	processIDs, err := linuxGuardianChildProcessIDsAt(taskRoot, processRoot, 42)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int{303}, processIDs)
+}
+
+func writeLinuxProcessStatus(t *testing.T, processRoot, processID, name string, parentProcessID int) {
+	t.Helper()
+
+	processDirectory := filepath.Join(processRoot, processID)
+	require.NoError(t, os.MkdirAll(processDirectory, 0o700))
+	contents := []byte("Name:\t" + name + "\nPPid:\t" + strconv.Itoa(parentProcessID) + "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(processDirectory, "status"), contents, 0o600))
+}

--- a/internal/cmdtestrunner/process_tree_unix.go
+++ b/internal/cmdtestrunner/process_tree_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows && !darwin && !linux
+
+package cmdtestrunner
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// runProcessTree retains the pre-supervision behavior on operating systems
+// where Ooze does not yet provide an identity-stable process-tree barrier.
+func runProcessTree(command *exec.Cmd) (error, error) {
+	err := command.Start()
+	if err != nil {
+		return nil, fmt.Errorf("start test command: %w", err)
+	}
+
+	commandErr, waitErr := classifyCommandWait(command.Wait())
+
+	return commandErr, waitErr
+}

--- a/internal/cmdtestrunner/process_tree_windows.go
+++ b/internal/cmdtestrunner/process_tree_windows.go
@@ -1,0 +1,397 @@
+//go:build windows
+
+package cmdtestrunner
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	processTreeTerminationTimeout             = 5 * time.Second
+	processTreeTerminationTimeoutMilliseconds = uint32(processTreeTerminationTimeout / time.Millisecond)
+	jobProcessQueryMaximumAttempts            = 32
+)
+
+var (
+	errProcessTreeTerminationTimeout = errors.New("process tree termination timed out")
+	errUnexpectedProcessWaitStatus   = errors.New("unexpected process wait status")
+	errJobProcessCapacityOverflow    = errors.New("job process capacity overflow")
+	errJobProcessQueryLimit          = errors.New("job process query retry limit reached")
+	errUnexpectedJobProcessList      = errors.New("unexpected job process list")
+	kernel32                         = windows.NewLazySystemDLL("kernel32.dll")
+	isProcessInJob                   = kernel32.NewProc("IsProcessInJob")
+)
+
+func runProcessTree(command *exec.Cmd) (error, error) {
+	job, err := newProcessTreeJob()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = windows.CloseHandle(job) }()
+
+	//nolint:exhaustruct // Other process attributes retain OS defaults.
+	command.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_SUSPENDED}
+	err = command.Start()
+	if err != nil {
+		return nil, fmt.Errorf("start supervised command: %w", err)
+	}
+
+	processID := uint32(command.Process.Pid) //nolint:gosec // Windows process IDs are 32-bit values.
+	err = assignProcessToJob(job, processID)
+	if err != nil {
+		cleanupErr := terminateUnsupervisedProcessAndWait(command)
+
+		return nil, errors.Join(err, cleanupErr)
+	}
+
+	err = resumeProcess(processID)
+	if err != nil {
+		cleanupErr := terminateJobProcessesAndWait(command, job)
+
+		return nil, errors.Join(err, cleanupErr)
+	}
+
+	commandErr, waitErr := classifyCommandWait(command.Wait())
+	jobTerminationErr := terminateJobProcesses(job)
+	supervisionErr := errors.Join(waitErr, jobTerminationErr)
+
+	return commandErr, supervisionErr
+}
+
+func newProcessTreeJob() (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create process tree job: %w", err)
+	}
+
+	limits := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{} //nolint:exhaustruct // Only LimitFlags is configured.
+	limits.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	_, err = windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limits)),
+		uint32(unsafe.Sizeof(limits)),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+
+		return 0, fmt.Errorf("configure process tree job: %w", err)
+	}
+
+	return job, nil
+}
+
+func assignProcessToJob(job windows.Handle, processID uint32) error {
+	const access = windows.PROCESS_SET_QUOTA | windows.PROCESS_TERMINATE
+
+	process, err := windows.OpenProcess(access, false, processID)
+	if err != nil {
+		return fmt.Errorf("open process %d for supervision: %w", processID, err)
+	}
+	defer func() { _ = windows.CloseHandle(process) }()
+
+	err = windows.AssignProcessToJobObject(job, process)
+	if err != nil {
+		return fmt.Errorf("assign process %d to job: %w", processID, err)
+	}
+
+	return nil
+}
+
+func resumeProcess(processID uint32) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("snapshot threads for process %d: %w", processID, err)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	//nolint:exhaustruct // Thread32First populates all fields except Size.
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	err = windows.Thread32First(snapshot, &entry)
+	if err != nil {
+		return fmt.Errorf("inspect first thread for process %d: %w", processID, err)
+	}
+
+	for {
+		if entry.OwnerProcessID == processID {
+			return resumeThread(entry.ThreadID, processID)
+		}
+
+		err = windows.Thread32Next(snapshot, &entry)
+		if errors.Is(err, syscall.ERROR_NO_MORE_FILES) {
+			return fmt.Errorf("find suspended thread for process %d: %w", processID, err)
+		}
+		if err != nil {
+			return fmt.Errorf("inspect next thread for process %d: %w", processID, err)
+		}
+	}
+}
+
+func resumeThread(threadID, processID uint32) error {
+	thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, threadID)
+	if err != nil {
+		return fmt.Errorf("open thread %d for process %d: %w", threadID, processID, err)
+	}
+	defer func() { _ = windows.CloseHandle(thread) }()
+
+	_, err = windows.ResumeThread(thread)
+	if err != nil {
+		return fmt.Errorf("resume thread %d for process %d: %w", threadID, processID, err)
+	}
+
+	return nil
+}
+
+func terminateUnsupervisedProcessAndWait(command *exec.Cmd) error {
+	processID := uint32(command.Process.Pid) //nolint:gosec // Windows process IDs are 32-bit values.
+	killErr := command.Process.Kill()
+	waitErr := waitForProcessExit(processID)
+	if waitErr != nil {
+		return errors.Join(killErr, waitErr)
+	}
+
+	return errors.Join(killErr, reapTerminatedCommand(command))
+}
+
+func terminateJobProcessesAndWait(command *exec.Cmd, job windows.Handle) error {
+	processID := uint32(command.Process.Pid) //nolint:gosec // Windows process IDs are 32-bit values.
+	terminateErr := windows.TerminateJobObject(job, 1)
+	waitErr := waitForProcessExit(processID)
+	if waitErr != nil {
+		return errors.Join(terminateErr, waitErr)
+	}
+
+	return errors.Join(terminateErr, reapTerminatedCommand(command))
+}
+
+func waitForProcessExit(processID uint32) error {
+	process, err := windows.OpenProcess(windows.SYNCHRONIZE, false, processID)
+	if err != nil {
+		return fmt.Errorf("open process %d to await termination: %w", processID, err)
+	}
+	defer func() { _ = windows.CloseHandle(process) }()
+
+	status, err := windows.WaitForSingleObject(process, processTreeTerminationTimeoutMilliseconds)
+	if err != nil {
+		return fmt.Errorf("await process %d termination: %w", processID, err)
+	}
+	if status == uint32(windows.WAIT_TIMEOUT) {
+		return fmt.Errorf("%w after %s", errProcessTreeTerminationTimeout, processTreeTerminationTimeout)
+	}
+	if status != uint32(windows.WAIT_OBJECT_0) {
+		return fmt.Errorf("await process %d termination: %w %d", processID, errUnexpectedProcessWaitStatus, status)
+	}
+
+	return nil
+}
+
+func reapTerminatedCommand(command *exec.Cmd) error {
+	_, waitErr := classifyCommandWait(command.Wait())
+
+	return waitErr
+}
+
+func terminateJobProcesses(job windows.Handle) error {
+	processes, err := retainJobProcesses(job)
+	if err != nil {
+		return err
+	}
+
+	err = windows.TerminateJobObject(job, 1)
+	if err != nil {
+		closeProcessHandles(processes)
+
+		return fmt.Errorf("terminate process tree: %w", err)
+	}
+	deadline := time.Now().Add(processTreeTerminationTimeout)
+
+	err = waitForProcessesAndClose(processes, deadline)
+	if err != nil {
+		return err
+	}
+
+	lateProcesses, err := retainJobProcesses(job)
+	if err != nil {
+		return err
+	}
+
+	return waitForProcessesAndClose(lateProcesses, deadline)
+}
+
+func retainJobProcesses(job windows.Handle) ([]windows.Handle, error) {
+	processIDs, err := jobProcessIDs(job)
+	if err != nil {
+		return nil, err
+	}
+
+	processes := make([]windows.Handle, 0, len(processIDs))
+	for _, processID := range processIDs {
+		const access = windows.PROCESS_QUERY_LIMITED_INFORMATION | windows.SYNCHRONIZE
+		process, openErr := windows.OpenProcess(access, false, processID)
+		if errors.Is(openErr, windows.ERROR_INVALID_PARAMETER) {
+			continue
+		}
+		if openErr != nil {
+			closeProcessHandles(processes)
+
+			return nil, fmt.Errorf("retain job process %d: %w", processID, openErr)
+		}
+
+		belongsToJob, membershipErr := processBelongsToJob(process, job)
+		if membershipErr != nil {
+			_ = windows.CloseHandle(process)
+			closeProcessHandles(processes)
+
+			return nil, membershipErr
+		}
+		if !belongsToJob {
+			_ = windows.CloseHandle(process)
+
+			continue
+		}
+
+		processes = append(processes, process)
+	}
+
+	return processes, nil
+}
+
+func processBelongsToJob(process, job windows.Handle) (bool, error) {
+	var belongsToJob int32
+	succeeded, _, callErr := isProcessInJob.Call(
+		uintptr(process),
+		uintptr(job),
+		uintptr(unsafe.Pointer(&belongsToJob)),
+	)
+	if succeeded == 0 {
+		return false, fmt.Errorf("validate retained process job membership: %w", callErr)
+	}
+
+	return belongsToJob != 0, nil
+}
+
+func jobProcessIDs(job windows.Handle) ([]uint32, error) {
+	const initialProcessCapacity = 16
+
+	processCapacity := uint32(initialProcessCapacity)
+	for range jobProcessQueryMaximumAttempts {
+		processIDs, assignedProcesses, err := queryJobProcessIDs(job, processCapacity)
+		if err == nil {
+			return processIDs, nil
+		}
+		if !errors.Is(err, windows.ERROR_MORE_DATA) {
+			return nil, fmt.Errorf("inspect process tree: %w", err)
+		}
+
+		processCapacity, err = nextJobProcessCapacity(processCapacity, assignedProcesses)
+		if err != nil {
+			return nil, fmt.Errorf("inspect process tree: %w", err)
+		}
+	}
+
+	return nil, fmt.Errorf("inspect process tree: %w", errJobProcessQueryLimit)
+}
+
+func nextJobProcessCapacity(current, assigned uint32) (uint32, error) {
+	if assigned > current {
+		return assigned, nil
+	}
+	if current > ^uint32(0)/2 {
+		return 0, errJobProcessCapacityOverflow
+	}
+
+	return current * 2, nil
+}
+
+func queryJobProcessIDs(job windows.Handle, processCapacity uint32) ([]uint32, uint32, error) {
+	const headerSize = unsafe.Sizeof(uint32(0)) * 2
+	const processIDSize = unsafe.Sizeof(uintptr(0))
+
+	bufferSize := headerSize + uintptr(processCapacity)*processIDSize
+	if bufferSize > uintptr(^uint32(0)) {
+		return nil, 0, fmt.Errorf("query job process IDs: %w", errJobProcessCapacityOverflow)
+	}
+	buffer := make([]uintptr, (bufferSize+processIDSize-1)/processIDSize)
+	bufferPointer := unsafe.Pointer(&buffer[0])
+	err := windows.QueryInformationJobObject(
+		job,
+		windows.JobObjectBasicProcessIdList,
+		uintptr(bufferPointer),
+		uint32(bufferSize),
+		nil,
+	)
+	if err != nil {
+		err = fmt.Errorf("query job process IDs: %w", err)
+	}
+
+	assignedProcesses := *(*uint32)(bufferPointer)
+	listedProcesses := *(*uint32)(unsafe.Add(bufferPointer, unsafe.Sizeof(uint32(0))))
+	if err != nil {
+		return nil, assignedProcesses, err
+	}
+	if listedProcesses > processCapacity {
+		return nil, assignedProcesses, fmt.Errorf(
+			"query job process IDs: %w: listed %d processes in a %d-process buffer",
+			errUnexpectedJobProcessList,
+			listedProcesses,
+			processCapacity,
+		)
+	}
+	processIDValues := unsafe.Slice((*uintptr)(unsafe.Add(bufferPointer, headerSize)), listedProcesses)
+	processIDs := make([]uint32, 0, listedProcesses)
+	for _, processID := range processIDValues {
+		processIDs = append(processIDs, uint32(processID)) //nolint:gosec // Windows process IDs are 32-bit values.
+	}
+
+	return processIDs, assignedProcesses, err
+}
+
+func waitForProcessHandle(process windows.Handle, deadline time.Time) error {
+	timeout := processWaitTimeoutMilliseconds(time.Until(deadline))
+	status, err := windows.WaitForSingleObject(process, timeout)
+	if err != nil {
+		return fmt.Errorf("await process termination: %w", err)
+	}
+	if status == uint32(windows.WAIT_TIMEOUT) {
+		return fmt.Errorf("%w after %s", errProcessTreeTerminationTimeout, processTreeTerminationTimeout)
+	}
+	if status != uint32(windows.WAIT_OBJECT_0) {
+		return fmt.Errorf("await process termination: %w %d", errUnexpectedProcessWaitStatus, status)
+	}
+
+	return nil
+}
+
+func processWaitTimeoutMilliseconds(remaining time.Duration) uint32 {
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining >= processTreeTerminationTimeout {
+		return processTreeTerminationTimeoutMilliseconds
+	}
+
+	return uint32((remaining + time.Millisecond - 1) / time.Millisecond) //nolint:gosec // Capped above at five seconds.
+}
+
+func waitForProcessesAndClose(processes []windows.Handle, deadline time.Time) error {
+	var waitErr error
+	for _, process := range processes {
+		waitErr = errors.Join(waitErr, waitForProcessHandle(process, deadline))
+	}
+	closeProcessHandles(processes)
+
+	return waitErr
+}
+
+func closeProcessHandles(processes []windows.Handle) {
+	for _, process := range processes {
+		_ = windows.CloseHandle(process)
+	}
+}

--- a/internal/cmdtestrunner/process_tree_windows_internal_test.go
+++ b/internal/cmdtestrunner/process_tree_windows_internal_test.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package cmdtestrunner
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextJobProcessCapacity(t *testing.T) {
+	t.Run("uses the assigned process count when it grew", func(t *testing.T) {
+		capacity, err := nextJobProcessCapacity(16, 23)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(23), capacity)
+	})
+
+	t.Run("grows monotonically when the assigned process count did not grow", func(t *testing.T) {
+		capacity, err := nextJobProcessCapacity(16, 16)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(32), capacity)
+	})
+
+	t.Run("rejects capacity overflow", func(t *testing.T) {
+		_, err := nextJobProcessCapacity(math.MaxUint32, 0)
+
+		assert.ErrorIs(t, err, errJobProcessCapacityOverflow)
+	})
+
+	t.Run("doubles the largest capacity that still fits", func(t *testing.T) {
+		capacity, err := nextJobProcessCapacity(math.MaxUint32/2, 0)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(math.MaxUint32-1), capacity)
+	})
+
+	t.Run("rejects the smallest capacity that overflows", func(t *testing.T) {
+		_, err := nextJobProcessCapacity(math.MaxUint32/2+1, 0)
+
+		assert.ErrorIs(t, err, errJobProcessCapacityOverflow)
+	})
+}
+
+func TestProcessWaitTimeoutMilliseconds(t *testing.T) {
+	assert.Equal(t, uint32(0), processWaitTimeoutMilliseconds(-time.Nanosecond))
+	assert.Equal(t, uint32(0), processWaitTimeoutMilliseconds(0))
+	assert.Equal(t, uint32(1), processWaitTimeoutMilliseconds(time.Nanosecond))
+	assert.Equal(t, uint32(1), processWaitTimeoutMilliseconds(time.Millisecond))
+	assert.Equal(t, uint32(2), processWaitTimeoutMilliseconds(time.Millisecond+time.Nanosecond))
+	assert.Equal(
+		t,
+		processTreeTerminationTimeoutMilliseconds,
+		processWaitTimeoutMilliseconds(processTreeTerminationTimeout+time.Second),
+	)
+}


### PR DESCRIPTION
## Summary

- supervise test commands and their descendants with OS-backed lifecycle barriers on Linux, macOS, and Windows
- use Windows Job Objects and suspended startup so descendants cannot escape before assignment
- use dedicated Linux and macOS guardians so command completion and descendant teardown remain identity-stable
- retain the established behavior on other Unix systems instead of signalling a process group after its leader has been reaped
- distinguish command failures from supervision failures so infrastructure errors cannot inflate the mutation score

## Regression

The helper command starts a descendant that waits until `CMDTestRunner.Test` returns before attempting to modify its repository. The regression covers descendants that retain inherited output handles and descendants that close those handles early. It passes only when the original descendant is proven non-executable and unable to write after the interface returns.

Additional regressions cover a macOS launcher that exits before suspension, Linux kernels without the task `children` interface, and bounded Windows Job Object membership queries.

## Validation

- 258 tests pass with race detection, coverage, and shuffled order; 1 unrelated test remains skipped
- repository lint and Linux/Windows target lint pass
- Linux lifecycle regressions pass natively in an arm64 Linux container
- Linux, Windows, FreeBSD, OpenBSD, AIX, illumos, and Solaris representative targets cross-compile
- the OS Compatibility workflow exercises Linux, macOS, and Windows before merge
