### PR TITLE
ci: add macOS 26 mutation tests

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - name: Ubuntu 24.04
             runner: ubuntu-24.04
+          - name: macOS 26
+            runner: macos-26
           - name: Windows 2025
             runner: windows-2025
     steps:


### PR DESCRIPTION
Adds macOS 26 to the mutation-test matrix, matching the existing OS compatibility runner convention.

Validation:
- all workflow YAML files parse successfully
- actionlint v1.7.7 passes for mutation.yml
- golangci-lint 2.12.2 passes
- fail-fast Go suite passes (259 tests, 1 skipped)