### PR TITLE
fix: respect Go build constraints during mutation discovery

### DIFF
--- a/internal/fsrepository/fsrepository.go
+++ b/internal/fsrepository/fsrepository.go
@@ -3,6 +3,7 @@ package fsrepository
 import (
 	"errors"
 	"fmt"
+	"go/build"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,7 +15,8 @@ import (
 )
 
 type FSRepository struct {
-	root string
+	root         string
+	buildContext build.Context
 }
 
 func New(root string) *FSRepository {
@@ -37,7 +39,8 @@ func New(root string) *FSRepository {
 	}
 
 	return &FSRepository{
-		root: absRoot,
+		root:         absRoot,
+		buildContext: build.Default,
 	}
 }
 
@@ -50,6 +53,14 @@ func (r *FSRepository) ListGoSourceFiles() []*gosourcefile.GoSourceFile {
 		}
 
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+
+		matches, err := r.buildContext.MatchFile(filepath.Dir(path), entry.Name())
+		if err != nil {
+			return fmt.Errorf("match Go source file '%s' to build context: %w", path, err)
+		}
+		if !matches {
 			return nil
 		}
 

--- a/internal/fsrepository/fsrepository_test.go
+++ b/internal/fsrepository/fsrepository_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gtramontina/ooze/internal/fsrepository"
@@ -86,6 +87,28 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 		}, files)
 	})
 
+	t.Run("only includes source files matching the current build context", func(t *testing.T) {
+		dir := t.TempDir()
+		otherOS := "windows"
+		if runtime.GOOS == otherOS {
+			otherOS = "linux"
+		}
+
+		writeSourceFile(t, dir, "common.go", "package fixture\n")
+		writeSourceFile(t, dir, "filename_"+runtime.GOOS+".go", "package fixture\n")
+		writeSourceFile(t, dir, "filename_"+otherOS+".go", "package fixture\n")
+		writeSourceFile(t, dir, "constraint_current.go", "//go:build "+runtime.GOOS+"\n\npackage fixture\n")
+		writeSourceFile(t, dir, "constraint_other.go", "//go:build "+otherOS+"\n\npackage fixture\n")
+
+		repository := fsrepository.New(dir)
+		files := repository.ListGoSourceFiles()
+		assert.Equal(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.New("common.go", []byte("package fixture\n")),
+			gosourcefile.New("constraint_current.go", []byte("//go:build "+runtime.GOOS+"\n\npackage fixture\n")),
+			gosourcefile.New("filename_"+runtime.GOOS+".go", []byte("package fixture\n")),
+		}, files)
+	})
+
 	t.Run("recursive directories", func(t *testing.T) {
 		dir := t.TempDir()
 		assert.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o700))
@@ -122,6 +145,11 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 			gosourcefile.New("source1.go", []byte("source data 1")),
 		}, files)
 	})
+}
+
+func writeSourceFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	assert.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(contents), 0o600))
 }
 
 func TestFSRepository_MaterializeTemporaryRepository(t *testing.T) {

--- a/internal/fsrepository/fsrepository_test.go
+++ b/internal/fsrepository/fsrepository_test.go
@@ -93,7 +93,14 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 		if runtime.GOOS == otherOS {
 			otherOS = "linux"
 		}
+		otherArch := "amd64"
+		if runtime.GOARCH == otherArch {
+			otherArch = "arm64"
+		}
 
+		writeSourceFile(t, dir, "architecture_"+runtime.GOARCH+".go", "package fixture\n")
+		writeSourceFile(t, dir, "architecture_"+otherArch+".go", "package fixture\n")
+		writeSourceFile(t, dir, "combined_"+runtime.GOOS+"_"+runtime.GOARCH+".go", "package fixture\n")
 		writeSourceFile(t, dir, "common.go", "package fixture\n")
 		writeSourceFile(t, dir, "filename_"+runtime.GOOS+".go", "package fixture\n")
 		writeSourceFile(t, dir, "filename_"+otherOS+".go", "package fixture\n")
@@ -103,6 +110,8 @@ func TestFSRepository_ListGoSourceFiles(t *testing.T) {
 		repository := fsrepository.New(dir)
 		files := repository.ListGoSourceFiles()
 		assert.Equal(t, []*gosourcefile.GoSourceFile{
+			gosourcefile.New("architecture_"+runtime.GOARCH+".go", []byte("package fixture\n")),
+			gosourcefile.New("combined_"+runtime.GOOS+"_"+runtime.GOARCH+".go", []byte("package fixture\n")),
 			gosourcefile.New("common.go", []byte("package fixture\n")),
 			gosourcefile.New("constraint_current.go", []byte("//go:build "+runtime.GOOS+"\n\npackage fixture\n")),
 			gosourcefile.New("filename_"+runtime.GOOS+".go", []byte("package fixture\n")),

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ Mutations can also be domain/application-specific. Although, these are up to the
 
 It is worth mentioning that mutation tests can be quite expensive to run. Especially on larger code bases. And the reason is that for every mutation, on every source file, the entire suite of tests has to run. One can look at the bright side of this and think as an incentive to keep the test suites fast.
 
+Ooze only mutates source files included by the current platform's default Go build context. Files excluded by `GOOS`/`GOARCH` filename suffixes or `//go:build` constraints are skipped. Custom build tags passed only through `WithTestCommand` do not change source-file discovery.
+
 Mutation testing is a great ally in developing a robust code base and a reliable set of test suites.
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- filter mutation source discovery through the default Go build context
- skip files excluded by GOOS/GOARCH suffixes or `//go:build` constraints
- document discovery behavior and the custom-tag limitation

This preserves filesystem-based discovery for arbitrary directories and incomplete Go source; it does not require a valid module or package.

## Impact

On Linux, registered mutations fell from 468 to 252, a 46.2% reduction.

## Verification

- full `go test ./...` suite with Go 1.26.6
- race/coverage suite matching the repository test target
- golangci-lint 2.12.2: 0 issues
- independent Standards review: 0 findings
- independent Spec review: 0 findings

## Out of scope

A full Linux mutation campaign can separately abort when a mutation of `process_tree_linux.go` changes the re-executed guardian behavior and produces infrastructure exit code 125. This PR intentionally does not change timeout or process-supervision semantics.