### PR TITLE
Simplify self-mutation to one campaign per platform

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -70,4 +70,4 @@ jobs:
 
       - name: "🧬 Mutation Tests"
         shell: bash
-        run: ${{ matrix.test-command }} -timeout=60m -count=1 -v -tags=mutation -run=^TestMutation$
+        run: ${{ matrix.test-command }} -timeout=90m -count=1 -v -tags=mutation -run=^TestMutation$

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,120 +20,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 24.04 / repository
+          - name: Ubuntu 24.04
             runner: ubuntu-24.04
             toolchain: devbox
             go-command: devbox run -- go
             test-command: devbox run -- go test
-            mutation-test: TestMutationRepository
-          - name: Ubuntu 24.04 / attempt-system
-            runner: ubuntu-24.04
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationAttemptSystem
-          - name: Ubuntu 24.04 / campaign-runner
-            runner: ubuntu-24.04
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignRunner
-          - name: Ubuntu 24.04 / campaign-cycle
-            runner: ubuntu-24.04
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignCycle
-          - name: Ubuntu 24.04 / campaign-emergency
-            runner: ubuntu-24.04
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignEmergency
-          - name: Ubuntu 24.04 / campaign-effects
-            runner: ubuntu-24.04
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignEffects
-          - name: macOS 26 / repository
+          - name: macOS 26
             runner: macos-26
             toolchain: devbox
             go-command: devbox run -- go
             test-command: devbox run -- go test
-            mutation-test: TestMutationRepository
-          - name: macOS 26 / attempt-system
-            runner: macos-26
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationAttemptSystem
-          - name: macOS 26 / campaign-runner
-            runner: macos-26
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignRunner
-          - name: macOS 26 / campaign-cycle
-            runner: macos-26
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignCycle
-          - name: macOS 26 / campaign-emergency
-            runner: macos-26
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignEmergency
-          - name: macOS 26 / campaign-effects
-            runner: macos-26
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationCampaignEffects
-          - name: macOS 26 / darwin
-            runner: macos-26
-            toolchain: devbox
-            go-command: devbox run -- go
-            test-command: devbox run -- go test
-            mutation-test: TestMutationPlatform
-          - name: Windows 2025 / repository
+          - name: Windows 2025
             runner: windows-2025
             toolchain: raw-go
             go-command: go
             test-command: go test
-            mutation-test: TestMutationRepository
-          - name: Windows 2025 / attempt-system
-            runner: windows-2025
-            toolchain: raw-go
-            go-command: go
-            test-command: go test
-            mutation-test: TestMutationAttemptSystem
-          - name: Windows 2025 / campaign-runner
-            runner: windows-2025
-            toolchain: raw-go
-            go-command: go
-            test-command: go test
-            mutation-test: TestMutationCampaignRunner
-          - name: Windows 2025 / campaign-cycle
-            runner: windows-2025
-            toolchain: raw-go
-            go-command: go
-            test-command: go test
-            mutation-test: TestMutationCampaignCycle
-          - name: Windows 2025 / campaign-emergency
-            runner: windows-2025
-            toolchain: raw-go
-            go-command: go
-            test-command: go test
-            mutation-test: TestMutationCampaignEmergency
-          - name: Windows 2025 / campaign-effects
-            runner: windows-2025
-            toolchain: raw-go
-            go-command: go
-            test-command: go test
-            mutation-test: TestMutationCampaignEffects
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -168,4 +69,4 @@ jobs:
 
       - name: "🧬 Mutation Tests"
         shell: bash
-        run: ${{ matrix.test-command }} -timeout=30m -count=1 -v -tags=mutation -run=^${{ matrix.mutation-test }}$
+        run: ${{ matrix.test-command }} -timeout=60m -count=1 -v -tags=mutation -run=^TestMutation$

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,6 +1,7 @@
 name: "🧬 Mutation Tests"
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [ "🧩 Continuous Integration" ]
     branches: [ main ]
@@ -14,7 +15,7 @@ jobs:
 
   mutation:
     name: ${{ matrix.name }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Install Devbox
         if: ${{ matrix.toolchain == 'devbox' }}

--- a/internal/ooze/campaign.go
+++ b/internal/ooze/campaign.go
@@ -1821,7 +1821,7 @@ func (state campaignState) materializeAttempt(kind campaignAttemptKind, mutant m
 
 func (state campaignState) materializePrimaryBatch() (campaignState, []campaignEffect) {
 	limit := state.definition.peers
-	if state.definition.profile == SerialProfile {
+	if state.definition.profile == SerialProfile || state.singleAdmissionFallback {
 		limit = 1
 	}
 	active := 0

--- a/internal/ooze/managed_campaign_internal_test.go
+++ b/internal/ooze/managed_campaign_internal_test.go
@@ -222,6 +222,47 @@ func TestManagedCampaignConfirmsOverlapDeadlineAndTransitionsFutureAdmission(t *
 	assert.Equal(t, singleAdmission, shell.snapshot().mode, "launches/mode = %d/%v, want one confirmation and single admission", attempts.launches, shell.snapshot().mode)
 }
 
+func TestManagedCampaignResumesWithSingleAdmissionAfterConfirmationPressure(t *testing.T) {
+	repository := &managedMemoryRepository{files: []*gosourcefile.GoSourceFile{
+		gosourcefile.New("source.go", []byte("package source\nvar first = 0\nvar second = 0\nvar third = 0\nvar fourth = 0\n")),
+	}}
+	deadlineTrip := Tripped{Trip: AutomaticDeadlineTrip{}}
+	killed := Settled{Exit: ExitStatus{Code: 1}, ExecutionData: ExecutionData{CommandDuration: time.Second}}
+	attempts := &managedAttemptFixture{
+		waitForLaunches: 3,
+		launchesReady:   make(chan struct{}),
+		terminals: []Terminal{
+			Settled{Exit: ExitStatus{}, ExecutionData: ExecutionData{CommandDuration: time.Second}},
+			deadlineTrip, killed,
+			killed,
+			killed, killed,
+		},
+	}
+	runner := newManagedCampaignRunner(managedCampaignConstruction{
+		runtime: newProcessRuntimeShell(2), repository: repository,
+		temporaryDirectory: &managedTemporaryDirectory{}, attempts: attempts,
+	})
+	completed := make(chan managedCampaignResult, 1)
+	go func() {
+		completed <- runner.run(managedCampaignRequest{
+			identity: "campaign-a", lineage: 11, command: []string{"test"},
+			profile: AutomaticProfile, peers: 2, mutationTimeout: time.Minute,
+			viruses: []viruses.Virus{integerincrement.New()},
+		})
+	}()
+
+	select {
+	case result := <-completed:
+		outcome, ok := result.outcome.(completedOutcome)
+		require.True(t, ok, "outcome = %#v", result.outcome)
+		assert.Len(t, outcome.mutants, 4)
+		assert.True(t, outcome.singleAdmissionFallback)
+		assert.EqualValues(t, 6, attempts.launches)
+	case <-time.After(time.Second):
+		require.FailNow(t, "campaign did not resume with single admission after confirmation pressure")
+	}
+}
+
 func TestManagedCampaignAbortsResourceExhaustionAndTransitionsFutureAdmission(t *testing.T) {
 	repository := &managedMemoryRepository{files: []*gosourcefile.GoSourceFile{
 		gosourcefile.New("source.go", []byte("package source\nvar number = 0\n")),

--- a/makefile
+++ b/makefile
@@ -17,11 +17,7 @@ test.failfast: $(pre-reqs)
 .PHONY: test.failfast
 
 test.mutation: $(pre-reqs)
-	@tests="TestMutationRepository TestMutationAttemptSystem TestMutationCampaignRunner TestMutationCampaignCycle TestMutationCampaignEmergency TestMutationCampaignEffects"; \
-		if test "$$(go env GOOS)" = darwin; then tests="$$tests TestMutationPlatform"; fi; \
-		for test_name in $$tests; do \
-			go test -timeout=30m -count=1 -v -tags=mutation -run="^$$test_name$$"; \
-		done
+	@go test -timeout=60m -count=1 -v -tags=mutation -run=^TestMutation$
 .PHONY: test.mutation
 
 test.adversarial: $(pre-reqs)

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ test.failfast: $(pre-reqs)
 .PHONY: test.failfast
 
 test.mutation: $(pre-reqs)
-	@go test -timeout=60m -count=1 -v -tags=mutation -run=^TestMutation$
+	@go test -timeout=90m -count=1 -v -tags=mutation -run=^TestMutation$
 .PHONY: test.mutation
 
 test.adversarial: $(pre-reqs)

--- a/ooze_mutation_config_test.go
+++ b/ooze_mutation_config_test.go
@@ -3,7 +3,6 @@ package ooze_test
 import (
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/gtramontina/ooze"
@@ -12,118 +11,70 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type selfMutationShard struct {
-	name     string
-	paths    []string
-	packages []string
-}
-
-var selfMutationProductionShards = []selfMutationShard{
-	{name: "repository", paths: []string{
+func TestSelfMutationCampaignSelectsOnePlatformCatalogue(t *testing.T) {
+	portable := []string{
 		"internal/fsrepository/fstemporaryrepository.go",
 		"internal/fsrepository/remove_unix.go",
 		"internal/fsrepository/remove_windows.go",
 		"internal/ignoredrepository/ignoredrepository.go",
-	}, packages: []string{"./internal/fsrepository", "./internal/ignoredrepository"}},
-	{name: "attempt-system", paths: []string{
 		"internal/ooze/managed_attempt_system.go",
-	}, packages: []string{"./internal/ooze"}},
-	{name: "campaign-runner", paths: []string{
 		"internal/ooze/managed_campaign.go",
-	}, packages: []string{"./internal/ooze"}},
-	{name: "campaign-cycle", paths: []string{
 		"internal/ooze/managed_campaign_cycle.go",
-	}, packages: []string{"./internal/ooze"}},
-	{name: "campaign-emergency", paths: []string{
 		"internal/ooze/managed_campaign_emergency.go",
-	}, packages: []string{"./internal/ooze"}},
-	{name: "campaign-effects", paths: []string{
 		"internal/ooze/managed_campaign_effects.go",
-	}, packages: []string{"./internal/ooze"}},
-	{name: "darwin", paths: []string{
-		"internal/ooze/supervisor_native_darwin.go",
-	}, packages: []string{"./internal/ooze"}},
+	}
+	for _, test := range []struct {
+		name string
+		goos string
+		want []string
+	}{
+		{name: "Linux", goos: "linux", want: portable},
+		{name: "Windows", goos: "windows", want: portable},
+		{name: "Darwin", goos: "darwin", want: append(
+			append([]string(nil), portable...),
+			"internal/ooze/supervisor_native_darwin.go",
+		)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, selfMutationProductionPaths(test.goos))
+		})
+	}
 }
 
-func TestSelfMutationShardsPartitionSelectedProduction(t *testing.T) {
-	want := map[string]string{
-		"internal/fsrepository/fstemporaryrepository.go":  "repository",
-		"internal/fsrepository/remove_unix.go":            "repository",
-		"internal/fsrepository/remove_windows.go":         "repository",
-		"internal/ignoredrepository/ignoredrepository.go": "repository",
-		"internal/ooze/managed_attempt_system.go":         "attempt-system",
-		"internal/ooze/managed_campaign.go":               "campaign-runner",
-		"internal/ooze/managed_campaign_cycle.go":         "campaign-cycle",
-		"internal/ooze/managed_campaign_emergency.go":     "campaign-emergency",
-		"internal/ooze/managed_campaign_effects.go":       "campaign-effects",
-		"internal/ooze/supervisor_native_darwin.go":       "darwin",
-	}
-	seen := make(map[string]string)
-	for _, shard := range selfMutationProductionShards {
-		for _, path := range shard.paths {
-			{
-				previous := seen[path]
-				assert.EqualValues(t, "", previous, "production source %q appears in shards %q and %q", path, previous, shard.name)
-			}
-			seen[path] = shard.name
-		}
-	}
-	assert.Equal(t, want, seen, "mutation shard partition=%#v, want %#v", seen, want)
+var selfMutationPortableProductionPaths = []string{
+	"internal/fsrepository/fstemporaryrepository.go",
+	"internal/fsrepository/remove_unix.go",
+	"internal/fsrepository/remove_windows.go",
+	"internal/ignoredrepository/ignoredrepository.go",
+	"internal/ooze/managed_attempt_system.go",
+	"internal/ooze/managed_campaign.go",
+	"internal/ooze/managed_campaign_cycle.go",
+	"internal/ooze/managed_campaign_emergency.go",
+	"internal/ooze/managed_campaign_effects.go",
 }
 
-func TestSelfMutationShardsUseOwningPackageTests(t *testing.T) {
-	want := map[string][]string{
-		"repository":         {"./internal/fsrepository", "./internal/ignoredrepository"},
-		"attempt-system":     {"./internal/ooze"},
-		"campaign-runner":    {"./internal/ooze"},
-		"campaign-cycle":     {"./internal/ooze"},
-		"campaign-emergency": {"./internal/ooze"},
-		"campaign-effects":   {"./internal/ooze"},
-		"darwin":             {"./internal/ooze"},
+func selfMutationProductionPaths(goos string) []string {
+	paths := append([]string(nil), selfMutationPortableProductionPaths...)
+	if goos == "darwin" {
+		paths = append(paths, "internal/ooze/supervisor_native_darwin.go")
 	}
-	for _, shard := range selfMutationProductionShards {
-		assert.Equal(t, want[shard.name], shard.packages, "mutation shard %q packages=%#v, want %#v", shard.name, shard.packages, want[shard.name])
-		for _, packagePattern := range shard.packages {
-			assert.NotEqual(t, "./...", packagePattern, "mutation shard %q repeats the full module test suite", shard.name)
-		}
-	}
+
+	return paths
 }
 
 const selfMutationSubprocessSkip = "^(TestDarwinNativeSupervisorCapturesEscapeeBehindLiveGroupMember|TestDarwinNativeSupervisorTripsAutomaticDescendantFuse|TestNativeSupervisorDrainsWideFanout)$"
 
-func selfMutationOptions(shardName string) []ooze.Option {
-	shard, found := selfMutationShardNamed(shardName)
-	if !found {
-		panic("unknown self-mutation shard " + shardName)
-	}
+func selfMutationOptions() []ooze.Option {
 	return []ooze.Option{
 		ooze.ForceColors(),
 		ooze.WithRepositoryRoot("."),
-		withSelfMutationProductionCatalogue(shard.paths),
+		withSelfMutationProductionCatalogue(selfMutationProductionPaths(runtime.GOOS)),
 		ooze.WithTestCommand("gotestsum --format-hide-empty-pkg --max-fails=1 -- -failfast -skip=" +
-			selfMutationSubprocessSkip + " " + strings.Join(shard.packages, " ")),
+			selfMutationSubprocessSkip +
+			" ./internal/fsrepository ./internal/ignoredrepository ./internal/ooze"),
 		ooze.WithMinimumThreshold(0.5),
 		ooze.IgnoreSourceFiles("(^release\\.go$|testdata\\/.*)"),
 	}
-}
-
-func selfMutationShardNamed(name string) (selfMutationShard, bool) {
-	for _, shard := range selfMutationProductionShards {
-		if shard.name == name {
-			return shard, true
-		}
-	}
-
-	return selfMutationShard{}, false
-}
-
-func activeSelfMutationShards() []selfMutationShard {
-	active := selfMutationProductionShards[:len(selfMutationProductionShards)-1]
-	if runtime.GOOS == "darwin" {
-		active = selfMutationProductionShards
-	}
-
-	return active
 }
 
 func withSelfMutationProductionCatalogue(paths []string) ooze.Option {
@@ -189,21 +140,20 @@ func selectSelfMutationSources(
 }
 
 func TestSelfMutationCatalogueIsProportionalToChangedProduction(t *testing.T) {
-	for _, shard := range activeSelfMutationShards() {
-		configured := ooze.Options{}
-		for _, option := range selfMutationOptions(shard.name) {
-			configured = option(configured)
-		}
-		allowed := make(map[string]struct{}, len(shard.paths))
-		for _, path := range shard.paths {
-			allowed[path] = struct{}{}
-		}
-		assertSelfMutationCatalogue(t, configured.Repository.ListGoSourceFiles(), allowed)
-		snapshot := configured.Repository.MaterializeTemporaryRepository(t.TempDir())
-		assertSelfMutationCatalogue(t, snapshot.ListGoSourceFiles(), allowed)
-		nested := snapshot.MaterializeTemporaryRepository(t.TempDir())
-		assertSelfMutationCatalogue(t, nested.ListGoSourceFiles(), allowed)
+	configured := ooze.Options{}
+	for _, option := range selfMutationOptions() {
+		configured = option(configured)
 	}
+	paths := selfMutationProductionPaths(runtime.GOOS)
+	allowed := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		allowed[path] = struct{}{}
+	}
+	assertSelfMutationCatalogue(t, configured.Repository.ListGoSourceFiles(), allowed)
+	snapshot := configured.Repository.MaterializeTemporaryRepository(t.TempDir())
+	assertSelfMutationCatalogue(t, snapshot.ListGoSourceFiles(), allowed)
+	nested := snapshot.MaterializeTemporaryRepository(t.TempDir())
+	assertSelfMutationCatalogue(t, nested.ListGoSourceFiles(), allowed)
 }
 
 func assertSelfMutationCatalogue(

--- a/ooze_mutation_config_test.go
+++ b/ooze_mutation_config_test.go
@@ -73,7 +73,6 @@ func selfMutationOptions() []ooze.Option {
 			selfMutationSubprocessSkip +
 			" ./internal/fsrepository ./internal/ignoredrepository ./internal/ooze"),
 		ooze.WithMinimumThreshold(0.5),
-		ooze.IgnoreSourceFiles("(^release\\.go$|testdata\\/.*)"),
 	}
 }
 

--- a/ooze_mutation_test.go
+++ b/ooze_mutation_test.go
@@ -8,35 +8,6 @@ import (
 	"github.com/gtramontina/ooze"
 )
 
-func runMutationShard(t *testing.T, shardName string) {
-	t.Helper()
-	ooze.Release(t, selfMutationOptions(shardName)...)
-}
-
-func TestMutationRepository(t *testing.T) {
-	runMutationShard(t, "repository")
-}
-
-func TestMutationAttemptSystem(t *testing.T) {
-	runMutationShard(t, "attempt-system")
-}
-
-func TestMutationCampaignRunner(t *testing.T) {
-	runMutationShard(t, "campaign-runner")
-}
-
-func TestMutationCampaignCycle(t *testing.T) {
-	runMutationShard(t, "campaign-cycle")
-}
-
-func TestMutationCampaignEmergency(t *testing.T) {
-	runMutationShard(t, "campaign-emergency")
-}
-
-func TestMutationCampaignEffects(t *testing.T) {
-	runMutationShard(t, "campaign-effects")
-}
-
-func TestMutationPlatform(t *testing.T) {
-	runMutationShard(t, "darwin")
+func TestMutation(t *testing.T) {
+	ooze.Release(t, selfMutationOptions()...)
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -268,7 +268,7 @@ func TestMutationWorkflowRunsOneCampaignPerOperatingSystem(t *testing.T) {
 		"go-command: devbox run -- go",
 		"test-command: devbox run -- go test",
 		"Verify pinned Go 1.26.6",
-		"-timeout=60m",
+		"-timeout=90m",
 		"-run=^TestMutation$",
 	)
 }
@@ -307,7 +307,7 @@ func TestMutationTargetRunsOneCampaign(t *testing.T) {
 	makefile := strings.ReplaceAll(string(contents), "\r\n", "\n")
 	requireContract(t, makefile, "mutation target",
 		"test.mutation: $(pre-reqs)",
-		"go test -timeout=60m -count=1 -v -tags=mutation -run=^TestMutation$",
+		"go test -timeout=90m -count=1 -v -tags=mutation -run=^TestMutation$",
 	)
 	assert.NotContains(t, makefile, "for test_name in")
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -38,7 +38,7 @@ func workflowJob(t *testing.T, path, name string) string {
 
 func TestSelfMutationSubprocessDoesNotExcludeRootEntryPoints(t *testing.T) {
 	configured := ooze.Options{}
-	for _, option := range selfMutationOptions("campaign-runner") {
+	for _, option := range selfMutationOptions() {
 		configured = option(configured)
 	}
 	var skip *regexp.Regexp
@@ -48,13 +48,13 @@ func TestSelfMutationSubprocessDoesNotExcludeRootEntryPoints(t *testing.T) {
 		}
 	}
 	require.NotNil(t, skip, "self-mutation subprocess has no test-selection exclusion")
-	assert.False(t, skip.MatchString("TestMutationCampaignRunner"), "self-mutation subprocess excludes a root entry point from an unselected package")
+	assert.False(t, skip.MatchString("TestMutation"), "self-mutation subprocess excludes the root entry point")
 	assert.False(t, skip.MatchString("TestOptions"), "self-mutation subprocess excludes an ordinary production test")
 }
 
 func TestSelfMutationSubprocessSkipsFilesystemReentrantNativeFixture(t *testing.T) {
 	configured := ooze.Options{}
-	for _, option := range selfMutationOptions("campaign-runner") {
+	for _, option := range selfMutationOptions() {
 		configured = option(configured)
 	}
 	var skip *regexp.Regexp
@@ -76,7 +76,7 @@ func TestSelfMutationSubprocessSkipsFilesystemReentrantNativeFixture(t *testing.
 
 func TestSelfMutationSubprocessExecutesManagedCampaignFixture(t *testing.T) {
 	configured := ooze.Options{}
-	for _, option := range selfMutationOptions("campaign-runner") {
+	for _, option := range selfMutationOptions() {
 		configured = option(configured)
 	}
 	arguments := make([]string, 0, len(configured.TestCommand)+1)
@@ -208,35 +208,20 @@ func requireNativeToolchains(t *testing.T, job string) {
 	})
 }
 
-func requireMutationShardRows(t *testing.T, job string) {
+func requireMutationCampaignRows(t *testing.T, job string) {
 	t.Helper()
-	want := map[string]string{
-		"Ubuntu 24.04 / repository":         "TestMutationRepository",
-		"Ubuntu 24.04 / attempt-system":     "TestMutationAttemptSystem",
-		"Ubuntu 24.04 / campaign-runner":    "TestMutationCampaignRunner",
-		"Ubuntu 24.04 / campaign-cycle":     "TestMutationCampaignCycle",
-		"Ubuntu 24.04 / campaign-emergency": "TestMutationCampaignEmergency",
-		"Ubuntu 24.04 / campaign-effects":   "TestMutationCampaignEffects",
-		"macOS 26 / repository":             "TestMutationRepository",
-		"macOS 26 / attempt-system":         "TestMutationAttemptSystem",
-		"macOS 26 / campaign-runner":        "TestMutationCampaignRunner",
-		"macOS 26 / campaign-cycle":         "TestMutationCampaignCycle",
-		"macOS 26 / campaign-emergency":     "TestMutationCampaignEmergency",
-		"macOS 26 / campaign-effects":       "TestMutationCampaignEffects",
-		"macOS 26 / darwin":                 "TestMutationPlatform",
-		"Windows 2025 / repository":         "TestMutationRepository",
-		"Windows 2025 / attempt-system":     "TestMutationAttemptSystem",
-		"Windows 2025 / campaign-runner":    "TestMutationCampaignRunner",
-		"Windows 2025 / campaign-cycle":     "TestMutationCampaignCycle",
-		"Windows 2025 / campaign-emergency": "TestMutationCampaignEmergency",
-		"Windows 2025 / campaign-effects":   "TestMutationCampaignEffects",
+	want := []string{
+		"Ubuntu 24.04",
+		"macOS 26",
+		"Windows 2025",
 	}
 	rows := workflowMatrixRows(t, job)
 	assert.Equal(t, len(want), len(rows), "mutation matrix has %d rows, want %d", len(rows), len(want))
-	for name, selection := range want {
-		requireMatrixRow(t, job, name, map[string]string{"mutation-test": selection})
+	for _, name := range want {
+		requireMatrixRow(t, job, name, nil)
 	}
 	assert.NotContains(t, job, "catalogue-shard:")
+	assert.NotContains(t, job, "mutation-test:")
 	assert.NotContains(t, job, "OOZE_", "mutation workflow uses a forbidden OOZE_* selector")
 }
 
@@ -264,30 +249,17 @@ func TestNativeWorkflowUsesSupportedToolchainsAndRejectsSkippedEvidence(t *testi
 	)
 }
 
-func TestMutationWorkflowUsesDevboxExceptForNativeWindows(t *testing.T) {
+func TestMutationWorkflowRunsOneCampaignPerOperatingSystem(t *testing.T) {
 	mutationJob := workflowJob(t, ".github/workflows/mutation.yml", "mutation")
 	requireNativeToolchains(t, mutationJob)
-	requireMutationShardRows(t, mutationJob)
+	requireMutationCampaignRows(t, mutationJob)
 	for _, name := range []string{
-		"Ubuntu 24.04 / repository", "Ubuntu 24.04 / attempt-system",
-		"Ubuntu 24.04 / campaign-runner", "Ubuntu 24.04 / campaign-effects",
-		"Ubuntu 24.04 / campaign-cycle",
-		"Ubuntu 24.04 / campaign-emergency",
-		"macOS 26 / repository", "macOS 26 / attempt-system",
-		"macOS 26 / campaign-runner", "macOS 26 / campaign-effects", "macOS 26 / darwin",
-		"macOS 26 / campaign-cycle",
-		"macOS 26 / campaign-emergency",
+		"Ubuntu 24.04",
+		"macOS 26",
 	} {
 		requireMatrixRow(t, mutationJob, name, map[string]string{"test-command": "devbox run -- go test"})
 	}
-	for _, name := range []string{
-		"Windows 2025 / repository", "Windows 2025 / attempt-system",
-		"Windows 2025 / campaign-runner", "Windows 2025 / campaign-effects",
-		"Windows 2025 / campaign-cycle",
-		"Windows 2025 / campaign-emergency",
-	} {
-		requireMatrixRow(t, mutationJob, name, map[string]string{"test-command": "go test"})
-	}
+	requireMatrixRow(t, mutationJob, "Windows 2025", map[string]string{"test-command": "go test"})
 	requireContract(t, mutationJob, "mutation job",
 		"toolchain: devbox",
 		"toolchain: raw-go",
@@ -296,7 +268,8 @@ func TestMutationWorkflowUsesDevboxExceptForNativeWindows(t *testing.T) {
 		"go-command: devbox run -- go",
 		"test-command: devbox run -- go test",
 		"Verify pinned Go 1.26.6",
-		"-run=^${{ matrix.mutation-test }}$",
+		"-timeout=60m",
+		"-run=^TestMutation$",
 	)
 }
 
@@ -317,6 +290,17 @@ func TestLintTargetUsesAcceptedNoConfigGate(t *testing.T) {
 	)
 }
 
+func TestMutationTargetRunsOneCampaign(t *testing.T) {
+	contents, err := os.ReadFile("makefile")
+	require.NoError(t, err)
+	makefile := strings.ReplaceAll(string(contents), "\r\n", "\n")
+	requireContract(t, makefile, "mutation target",
+		"test.mutation: $(pre-reqs)",
+		"go test -timeout=60m -count=1 -v -tags=mutation -run=^TestMutation$",
+	)
+	assert.NotContains(t, makefile, "for test_name in")
+}
+
 func TestCompatibilityWorkflowInstallsSelfMutationTestTool(t *testing.T) {
 	testJob := workflowJob(t, ".github/workflows/compatibility.yml", "test")
 	requireContract(t, testJob, "compatibility test job",
@@ -327,7 +311,7 @@ func TestCompatibilityWorkflowInstallsSelfMutationTestTool(t *testing.T) {
 
 func TestSelfMutationCommandKeepsAutomaticProfileWithinOwningPackages(t *testing.T) {
 	configured := ooze.Options{}
-	for _, option := range selfMutationOptions("campaign-runner") {
+	for _, option := range selfMutationOptions() {
 		configured = option(configured)
 	}
 	command := strings.Join(configured.TestCommand, " ")

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -253,13 +253,18 @@ func TestMutationWorkflowRunsOneCampaignPerOperatingSystem(t *testing.T) {
 	mutationJob := workflowJob(t, ".github/workflows/mutation.yml", "mutation")
 	requireNativeToolchains(t, mutationJob)
 	requireMutationCampaignRows(t, mutationJob)
-	for _, name := range []string{
-		"Ubuntu 24.04",
-		"macOS 26",
+	for _, platform := range []struct {
+		name        string
+		testCommand string
+	}{
+		{name: "Ubuntu 24.04", testCommand: "devbox run -- go test"},
+		{name: "macOS 26", testCommand: "devbox run -- go test"},
+		{name: "Windows 2025", testCommand: "go test"},
 	} {
-		requireMatrixRow(t, mutationJob, name, map[string]string{"test-command": "devbox run -- go test"})
+		t.Run(platform.name, func(t *testing.T) {
+			requireMatrixRow(t, mutationJob, platform.name, map[string]string{"test-command": platform.testCommand})
+		})
 	}
-	requireMatrixRow(t, mutationJob, "Windows 2025", map[string]string{"test-command": "go test"})
 	requireContract(t, mutationJob, "mutation job",
 		"toolchain: devbox",
 		"toolchain: raw-go",

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -273,6 +273,17 @@ func TestMutationWorkflowRunsOneCampaignPerOperatingSystem(t *testing.T) {
 	)
 }
 
+func TestMutationWorkflowCanRunCurrentRevisionManually(t *testing.T) {
+	contents, err := os.ReadFile(".github/workflows/mutation.yml")
+	require.NoError(t, err)
+	workflow := strings.ReplaceAll(string(contents), "\r\n", "\n")
+	requireContract(t, workflow, "manual mutation workflow",
+		"  workflow_dispatch:",
+		"if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}",
+		"ref: ${{ github.event.workflow_run.head_sha || github.sha }}",
+	)
+}
+
 func TestCIWorkflowRunsProductionSimulationContract(t *testing.T) {
 	testJob := workflowJob(t, ".github/workflows/ci.yml", "test")
 	requireContract(t, testJob, "CI production simulation contract",


### PR DESCRIPTION
Stacked on #82. This experiment replaces the 19 mutation shards with one real mutation campaign on each supported OS.

What changes:
- three CI rows: Ubuntu, macOS, Windows
- one `TestMutation` entry point and one platform catalogue
- the existing Devbox Linux/macOS and raw-Go Windows toolchain split
- a 90-minute outer bound

Exact-head hosted evidence at `c65b24b`:
- Ubuntu: 132 mutants, 99 detected, score 0.75, 39m03s
- macOS: 240 mutants, 154 detected, score 0.64, 47m39s
- Windows: 136 mutants, 104 detected, score 0.76, 53m51s
- workflow run: https://github.com/gtramontina/ooze/actions/runs/33024995409

The first hosted macOS run exposed a post-confirmation single-admission deadlock. The campaign reducer still materialized a peer-sized batch after the runtime had entered single-admission fallback. The first request was granted but its start was deferred; the second request then waited for capacity and prevented that start from running. `c65b24b` fixes the reducer-owned batch policy and adds a deterministic bounded regression. The successful 47m39s rerun confirms that the earlier 90-minute result was a deadlock, not normal runtime.

Local evidence:
- focused regression under race, count 20
- full race/coverage suite
- Darwin adversarial suite
- six cross-build targets
- isolated no-config lint, 0 issues
- final Standards and Spec reviews, no findings
- all six commits signed and verified

Important semantic difference:
- the 0.50 threshold is platform-wide. Unlike per-shard thresholds, a strong area can offset a weak one. This is the original whole-campaign model and should be reviewed deliberately.

This PR is for comparison and measurement. Do not merge it yet.
